### PR TITLE
Avoid Please provide a source image with `from` prior to commit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 These DockerFiles enable running PowerShell in a container for each Linux distribution we support.
 
-This requires an up-to-date version of Docker, such as 1.12.
+This requires Docker 17.05 or newer.
 It also expects you to be able to run Docker without `sudo`.
 Please follow [Docker's official instructions][install] to install `docker` correctly.
 


### PR DESCRIPTION
With docker 1.12, docker build fails with the above error for Dockerfiles that use `ARG` before `FROM`.