### PR TITLE
Fix PS_VERSION in Fedora images

### DIFF
--- a/release/preview/fedora27/docker/Dockerfile
+++ b/release/preview/fedora27/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG fromTag=27
 FROM fedora:${fromTag}
 
 ARG VCS_REF="none"
-ARG PS_VERSION=6.0.4
+ARG PS_VERSION=6.1.0~rc.1
 ARG IMAGE_NAME=mcr.microsoft.com/powershell:fedora27
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/release/preview/fedora28/docker/Dockerfile
+++ b/release/preview/fedora28/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG fromTag=28
 FROM fedora:${fromTag}
 
 ARG VCS_REF="none"
-ARG PS_VERSION=6.0.4
+ARG PS_VERSION=6.1.0~rc.1
 ARG IMAGE_NAME=mcr.microsoft.com/powershell:fedora28
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/release/stable/fedora27/docker/Dockerfile
+++ b/release/stable/fedora27/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG fromTag=27
 FROM fedora:${fromTag}
 
 ARG VCS_REF="none"
-ARG PS_VERSION=6.0.4
+ARG PS_VERSION=6.1.0
 ARG IMAGE_NAME=mcr.microsoft.com/powershell:fedora27
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/release/stable/fedora28/docker/Dockerfile
+++ b/release/stable/fedora28/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG fromTag=28
 FROM fedora:${fromTag}
 
 ARG VCS_REF="none"
-ARG PS_VERSION=6.0.4
+ARG PS_VERSION=6.1.0
 ARG IMAGE_NAME=mcr.microsoft.com/powershell:fedora28
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \


### PR DESCRIPTION
## PR Summary

`PS_VERSION` in Dockerfiles for Fedora images are different
from other images.
```
$ grep PS_VERSION= release/*/*/*/Dockerfile
release/preview/alpine/docker/Dockerfile:ARG PS_VERSION=6.1.0-rc.1
release/preview/alpine/docker/Dockerfile:ARG PS_VERSION=6.1.0-rc.1
release/preview/centos7/docker/Dockerfile:ARG PS_VERSION=6.1.0~rc.1
release/preview/fedora27/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/preview/fedora28/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/preview/nanoserver/docker/Dockerfile:ARG PS_VERSION=6.1.0-rc.1
release/preview/nanoserver/docker/Dockerfile:ARG PS_VERSION=6.1.0-rc.1
release/preview/ubuntu14.04/docker/Dockerfile:ARG PS_VERSION=6.1.0~rc.1
release/preview/ubuntu16.04/docker/Dockerfile:ARG PS_VERSION=6.1.0~rc.1
release/preview/ubuntu18.04/docker/Dockerfile:ARG PS_VERSION=6.1.0~rc.1
release/preview/windowsservercore/docker/Dockerfile:ARG PS_VERSION=6.1.0-rc.1
release/servicing/centos7/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/servicing/fedora27/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/servicing/nanoserver/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/servicing/nanoserver/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/servicing/ubuntu14.04/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/servicing/ubuntu16.04/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/servicing/windowsservercore/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/stable/alpine/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/alpine/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/centos7/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/debian8/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/debian9/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/fedora27/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/stable/fedora28/docker/Dockerfile:ARG PS_VERSION=6.0.4
release/stable/nanoserver/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/nanoserver/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/opensuse423/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/opensuse423/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/ubuntu14.04/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/ubuntu16.04/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/ubuntu18.04/docker/Dockerfile:ARG PS_VERSION=6.1.0
release/stable/windowsservercore/docker/Dockerfile:ARG PS_VERSION=6.1.0
```
This commit fixes them.
* release/preview/fedora27: 6.0.4 -> 6.1.0~rc.1
* release/preview/fedora28: 6.0.4 -> 6.1.0~rc.1
* release/stable/fedora27: 6.0.4 -> 6.1.0
* release/stable/fedora28: 6.0.4 -> 6.1.0

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [X] Not Applicable
  - **OR**
    - [ ] Update [README.powershell.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershell.md)
    - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
