### PR TITLE
Add "less" package to Linux images for "help" command

### DIFF
--- a/release/preview/alpine/docker/Dockerfile
+++ b/release/preview/alpine/docker/Dockerfile
@@ -53,6 +53,7 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
 # Install dotnet dependencies and ca-certificates
 RUN apk add --no-cache \
     ca-certificates \
+    less \
     \
     # PSReadline/console dependencies
     ncurses-terminfo-base \

--- a/release/preview/centos7/docker/Dockerfile
+++ b/release/preview/centos7/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 # Install dependencies and clean up
 RUN yum install -y \
         curl \
+        less \
     && yum clean all
 
 # Download and configure Microsoft Repository config file

--- a/release/preview/fedora27/docker/Dockerfile
+++ b/release/preview/fedora27/docker/Dockerfile
@@ -27,6 +27,7 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
 RUN dnf install -y \
         glibc-locale-source \
         compat-openssl10 \
+        less \
    && dnf upgrade-minimal -y --security \
    && dnf clean all
 

--- a/release/preview/fedora28/docker/Dockerfile
+++ b/release/preview/fedora28/docker/Dockerfile
@@ -27,6 +27,7 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
 RUN dnf install -y \
         glibc-locale-source \
         compat-openssl10 \
+        less \
    && dnf upgrade-minimal -y --security \
    && dnf clean all
 

--- a/release/preview/ubuntu14.04/docker/Dockerfile
+++ b/release/preview/ubuntu14.04/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
         apt-utils \
         ca-certificates \
         apt-transport-https \
+        less \
     && apt-get dist-upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/release/preview/ubuntu16.04/docker/Dockerfile
+++ b/release/preview/ubuntu16.04/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
         ca-certificates \
         apt-transport-https \
         locales \
+        less \
     && apt-get dist-upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/release/preview/ubuntu18.04/docker/Dockerfile
+++ b/release/preview/ubuntu18.04/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
         apt-transport-https \
         locales \
         gnupg2 \
+        less \
     && apt-get dist-upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/release/servicing/centos7/docker/Dockerfile
+++ b/release/servicing/centos7/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 # Install dependencies and clean up
 RUN yum install -y \
         curl \
+        less \
     && yum clean all
 
 # Download and configure Microsoft Repository config file

--- a/release/servicing/fedora27/docker/Dockerfile
+++ b/release/servicing/fedora27/docker/Dockerfile
@@ -27,6 +27,7 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
 RUN dnf install -y \
         glibc-locale-source \
         compat-openssl10 \
+        less \
         \
         # Added to workaround a dnf database corruption issue without this
         libunwind \

--- a/release/servicing/ubuntu14.04/docker/Dockerfile
+++ b/release/servicing/ubuntu14.04/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
         apt-utils \
         ca-certificates \
         apt-transport-https \
+        less \
     && apt-get dist-upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/release/servicing/ubuntu16.04/docker/Dockerfile
+++ b/release/servicing/ubuntu16.04/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
         ca-certificates \
         apt-transport-https \
         locales \
+        less \
     && apt-get dist-upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/release/stable/alpine/docker/Dockerfile
+++ b/release/stable/alpine/docker/Dockerfile
@@ -55,6 +55,7 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
 # Install dotnet dependencies and ca-certificates
 RUN apk add --no-cache \
         ca-certificates \
+        less \
         \
         # PSReadline/console dependencies
         ncurses-terminfo-base \

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 # Install dependencies and clean up
 RUN yum install -y \
         curl \
+        less \
     && yum clean all
 
 # Download and configure Microsoft Repository config file

--- a/release/stable/debian8/docker/Dockerfile
+++ b/release/stable/debian8/docker/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
         ca-certificates \
         curl \
         apt-transport-https \
-        locales
+        locales \
+        less
 
 # Setup the locale
 ENV LANG en_US.UTF-8

--- a/release/stable/debian9/docker/Dockerfile
+++ b/release/stable/debian9/docker/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update \
         curl \
         apt-transport-https \
         locales \
-        gnupg
+        gnupg \
+        less
 
 # Setup the locale
 ENV LANG en_US.UTF-8

--- a/release/stable/fedora27/docker/Dockerfile
+++ b/release/stable/fedora27/docker/Dockerfile
@@ -27,6 +27,7 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
 RUN dnf install -y \
         glibc-locale-source \
         compat-openssl10 \
+        less \
    && dnf upgrade-minimal -y --security \
    && dnf clean all
 

--- a/release/stable/fedora28/docker/Dockerfile
+++ b/release/stable/fedora28/docker/Dockerfile
@@ -27,6 +27,7 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
 RUN dnf install -y \
         glibc-locale-source \
         compat-openssl10 \
+        less \
    && dnf upgrade-minimal -y --security \
    && dnf clean all
 

--- a/release/stable/opensuse423/docker/Dockerfile
+++ b/release/stable/opensuse423/docker/Dockerfile
@@ -44,7 +44,8 @@ RUN zypper --non-interactive update --skip-interactive \
         glibc-i18ndata \
         libunwind \
         libicu \
-        openssl
+        openssl \
+        less
 
 # Copy only the files we need from the previous stag
 COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]

--- a/release/stable/ubuntu14.04/docker/Dockerfile
+++ b/release/stable/ubuntu14.04/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
         apt-utils \
         ca-certificates \
         apt-transport-https \
+        less \
     && apt-get dist-upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/release/stable/ubuntu16.04/docker/Dockerfile
+++ b/release/stable/ubuntu16.04/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
         ca-certificates \
         apt-transport-https \
         locales \
+        less \
     && apt-get dist-upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/release/stable/ubuntu18.04/docker/Dockerfile
+++ b/release/stable/ubuntu18.04/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
         apt-transport-https \
         locales \
         gnupg2 \
+        less \
     && apt-get dist-upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## PR Summary

On Linux systems, PowerShell's `help` command relies on `less` command
but currently it is not installed.

This commit adds `less` package to Linux images.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [X] Not Applicable
  - **OR**
    - [ ] Update [README.powershell.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershell.md)
    - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
