### PR TITLE
Make images use package files from Github

### DIFF
--- a/release/servicing/centos7/docker/Dockerfile
+++ b/release/servicing/centos7/docker/Dockerfile
@@ -12,12 +12,8 @@ ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$
 # downoad the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
-# Define Args and Env needed to create links
-ARG PS_INSTALL_VERSION=6
-ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
-    \
-    # Define ENVs for Localization/Globalization
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8
 

--- a/release/servicing/centos7/docker/Dockerfile
+++ b/release/servicing/centos7/docker/Dockerfile
@@ -1,10 +1,39 @@
 # Docker image file that describes an CentOS7 image with PowerShell installed from Microsoft YUM Repo
 ARG fromTag=7
+ARG imageRepo=centos
 
-FROM centos:${fromTag}
+FROM ${imageRepo}:${fromTag} AS installer-env
 
-ARG VCS_REF="none"
 ARG PS_VERSION=6.0.4
+ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+
+
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
+
+# Define Args and Env needed to create links
+ARG PS_INSTALL_VERSION=6
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
+    \
+    # Define ENVs for Localization/Globalization
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
+# Install dependencies and clean up
+RUN yum install -y /tmp/powershell.rpm \
+    && yum install -y \
+	# less is required for help in powershell
+	less \
+    && yum upgrade-minimal -y --security \
+    && yum clean all \
+    && localedef --charmap=UTF-8 --inputfile=en_US $LANG \
+    # remove powershell package
+    && rm /tmp/powershell.rpm
+
+# Define args needed only for the labels
+ARG VCS_REF="none"
 ARG IMAGE_NAME=mcr.microsoft.com/powershell:centos7
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
@@ -22,26 +51,6 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" \
       org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" \
       org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
-
-# Setup the locale
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
-RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
-
-# Install dependencies and clean up
-RUN yum install -y \
-        curl \
-        less \
-    && yum clean all
-
-# Download and configure Microsoft Repository config file
-RUN set -o pipefail \
-    && curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/microsoft.repo
-
-# Install latest powershell from Microsoft YUM Repo
-RUN yum install -y \
-        powershell-${PS_VERSION} \
-    && yum clean all
 
 # Use PowerShell as the default shell
 # Use array to avoid Docker prepending /bin/sh -c

--- a/release/servicing/fedora27/docker/Dockerfile
+++ b/release/servicing/fedora27/docker/Dockerfile
@@ -12,12 +12,8 @@ ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$
 # downoad the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
-# Define Args and Env needed to create links
-ARG PS_INSTALL_VERSION=6
-ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
-    \
-    # Define ENVs for Localization/Globalization
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8
 

--- a/release/servicing/fedora27/docker/Dockerfile
+++ b/release/servicing/fedora27/docker/Dockerfile
@@ -1,10 +1,43 @@
 # Docker image file that describes Fedora 27 image with PowerShell installed from Microsoft YUM Repo
 ARG fromTag=27
+ARG imageRepo=fedora
 
-FROM fedora:${fromTag}
+FROM ${imageRepo}:${fromTag} AS installer-env
 
-ARG VCS_REF="none"
 ARG PS_VERSION=6.0.4
+ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+
+
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
+
+# Define Args and Env needed to create links
+ARG PS_INSTALL_VERSION=6
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
+    \
+    # Define ENVs for Localization/Globalization
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
+# Install dependencies and clean up
+RUN dnf install -y /tmp/powershell.rpm \
+    && dnf install -y \
+	# less is needed for help
+	less \
+    # Needed to run localdef
+        glibc-locale-source \
+    # Invoke-WebRequest doesn't work correctly without this
+        compat-openssl10 \
+    && dnf upgrade-minimal -y --security \
+    && dnf clean all \
+    && localedef --charmap=UTF-8 --inputfile=en_US $LANG \
+    # remove powershell package
+    && rm /tmp/powershell.rpm
+
+# Define args needed only for the labels
+ARG VCS_REF="none"
 ARG IMAGE_NAME=mcr.microsoft.com/powershell:fedora27
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
@@ -22,31 +55,6 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" \
       org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" \
       org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
-
-# Install dependencies and clean up
-RUN dnf install -y \
-        glibc-locale-source \
-        compat-openssl10 \
-        less \
-        \
-        # Added to workaround a dnf database corruption issue without this
-        libunwind \
-   && dnf upgrade-minimal -y --security \
-   && dnf clean all
-
-# Setup the locale
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
-RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
-
-# Download and configure Microsoft Repository config file
-RUN set -o pipefail \
-    && curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/microsoft.repo
-
-# Install latest powershell from Microsoft YUM Repo
-RUN dnf install -y \
-        powershell-${PS_VERSION} \
-    && dnf clean all
 
 # Use PowerShell as the default shell
 # Use array to avoid Docker prepending /bin/sh -c

--- a/release/servicing/ubuntu16.04/docker/Dockerfile
+++ b/release/servicing/ubuntu16.04/docker/Dockerfile
@@ -1,12 +1,42 @@
 # Docker image file that describes an Ubuntu16.04 image with PowerShell installed from Microsoft APT Repo
 ARG fromTag=16.04
+ARG imageRepo=ubuntu
 
-FROM ubuntu:${fromTag}
+FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.0.4
-ARG PS_VERSION_POSTFIX=-1.ubuntu.16.04
-ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu16.04
+ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.16.04_amd64.deb
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+
+RUN echo ${PS_PACKAGE_URL}
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
+
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
+# Install dependencies and clean up
+RUN apt-get update \
+    && apt install -y /tmp/powershell.deb \
+    && apt-get install -y \
+    # less is required for help in powershell
+        less \
+    # requied to setup the locale
+        locales \
+    # required for SSL
+        ca-certificates \
+    && apt-get dist-upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && locale-gen $LANG && update-locale \
+    # remove powershell package
+    && rm /tmp/powershell.deb
+
+# Define args needed only for the labels
 ARG VCS_REF="none"
+ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu16.04
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" \
@@ -16,43 +46,13 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell-Docker" \
       org.label-schema.name="powershell" \
       org.label-schema.vendor="PowerShell" \
-      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.version=${PS_VERSION} \
       org.label-schema.schema-version="1.0" \
+      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.docker.cmd="docker run ${IMAGE_NAME} pwsh -c '$psversiontable'" \
       org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" \
       org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" \
       org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
-
-# Install dependencies and clean up
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        apt-utils \
-        ca-certificates \
-        apt-transport-https \
-        locales \
-        less \
-    && apt-get dist-upgrade -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Setup the locale
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
-RUN locale-gen $LANG && update-locale
-
-# Download the Microsoft repository GPG keys
-ADD https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb .
-
-# Register the Microsoft repository GPG keys
-RUN dpkg -i packages-microsoft-prod.deb
-
-# Install powershell from Microsoft Repo
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    powershell=${PS_VERSION}${PS_VERSION_POSTFIX} \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 # Use PowerShell as the default shell
 # Use array to avoid Docker prepending /bin/sh -c

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -12,12 +12,8 @@ ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$
 # downoad the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
-# Define Args and Env needed to create links
-ARG PS_INSTALL_VERSION=6
-ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
-    \
-    # Define ENVs for Localization/Globalization
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8
 

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -5,33 +5,12 @@ ARG imageRepo=centos
 FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.1.0
-ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-x64.tar.gz
+ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
-ARG PS_INSTALL_VERSION=6
 
-# define the folder we will be installing PowerShell to
-ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
 
-# Create the install folder
-RUN mkdir -p ${PS_INSTALL_FOLDER}
-
-# Install dependencies
-# Install dependencies and clean up
-RUN yum install -y \
-        tar
-
-# downoad the Linux tar.gz and save it
-ADD ${PS_PACKAGE_URL} /tmp/linux.tar.gz
-
-# Unzip the Linux tar.gz
-RUN tar zxf /tmp/linux.tar.gz -C ${PS_INSTALL_FOLDER}
-
-# ------ Second stage ------
-# Start a new stage so we lose all the tar.gz layers from the final image
-FROM ${imageRepo}:${fromTag}  
-
-# Copy only the files we need from the previous stage
-COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
 # Define Args and Env needed to create links
 ARG PS_INSTALL_VERSION=6
@@ -43,21 +22,18 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     LANG=en_US.UTF-8
 
 # Install dependencies and clean up
-RUN yum install -y \
-        libicu \
-        openssl-libs \
+RUN yum install -y /tmp/powershell.rpm \
+    && yum install -y \
 	# less is required for help in powershell
 	less \
     && yum upgrade-minimal -y --security \
     && yum clean all \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \
-    \
-    # Create the pwsh symbolic link that points to powershell
-    && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh
+    # remove powershell package
+    && rm /tmp/powershell.rpm
 
 # Define args needed only for the labels
 ARG VCS_REF="none"
-ARG PS_VERSION=6.1.0
 ARG IMAGE_NAME=mcr.microsoft.com/powershell:centos7
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -8,7 +8,6 @@ ARG PS_VERSION=6.1.0
 ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-
 # downoad the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 

--- a/release/stable/fedora27/docker/Dockerfile
+++ b/release/stable/fedora27/docker/Dockerfile
@@ -12,12 +12,8 @@ ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$
 # downoad the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
-# Define Args and Env needed to create links
-ARG PS_INSTALL_VERSION=6
-ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
-    \
-    # Define ENVs for Localization/Globalization
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8
 

--- a/release/stable/fedora27/docker/Dockerfile
+++ b/release/stable/fedora27/docker/Dockerfile
@@ -5,33 +5,12 @@ ARG imageRepo=fedora
 FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.1.0
-ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-x64.tar.gz
+ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
-ARG PS_INSTALL_VERSION=6
 
-# define the folder we will be installing PowerShell to
-ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
 
-# Create the install folder
-RUN mkdir -p ${PS_INSTALL_FOLDER}
-
-# Install dependencies
-# Install dependencies and clean up
-RUN dnf install -y \
-        tar
-
-# downoad the Linux tar.gz and save it
-ADD ${PS_PACKAGE_URL} /tmp/linux.tar.gz
-
-# Unzip the Linux tar.gz
-RUN tar zxf /tmp/linux.tar.gz -C ${PS_INSTALL_FOLDER}
-
-# ------ Second stage ------
-# Start a new stage so we lose all the tar.gz layers from the final image
-FROM ${imageRepo}:${fromTag}  
-
-# Copy only the files we need from the previous stage
-COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
 # Define Args and Env needed to create links
 ARG PS_INSTALL_VERSION=6
@@ -43,27 +22,22 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     LANG=en_US.UTF-8
 
 # Install dependencies and clean up
-RUN dnf install -y \
-        libicu \
-        openssl-libs \
+RUN dnf install -y /tmp/powershell.rpm \
+    && dnf install -y \
 	# less is needed for help
 	less \
-        \
-        # Needed to run localdef
+    # Needed to run localdef
         glibc-locale-source \
-        \
-        # Invoke-WebRequest doesn't work correctly without this
+    # Invoke-WebRequest doesn't work correctly without this
         compat-openssl10 \
     && dnf upgrade-minimal -y --security \
     && dnf clean all \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \
-    \
-    # Create the pwsh symbolic link that points to powershell
-    && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh
+    # remove powershell package
+    && rm /tmp/powershell.rpm
 
 # Define args needed only for the labels
 ARG VCS_REF="none"
-ARG PS_VERSION=6.1.0
 ARG IMAGE_NAME=mcr.microsoft.com/powershell:fedora27
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/release/stable/fedora28/docker/Dockerfile
+++ b/release/stable/fedora28/docker/Dockerfile
@@ -5,33 +5,12 @@ ARG imageRepo=fedora
 FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.1.0
-ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-x64.tar.gz
+ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
-ARG PS_INSTALL_VERSION=6
 
-# define the folder we will be installing PowerShell to
-ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
 
-# Create the install folder
-RUN mkdir -p ${PS_INSTALL_FOLDER}
-
-# Install dependencies
-# Install dependencies and clean up
-RUN dnf install -y \
-        tar
-
-# downoad the Linux tar.gz and save it
-ADD ${PS_PACKAGE_URL} /tmp/linux.tar.gz
-
-# Unzip the Linux tar.gz
-RUN tar zxf /tmp/linux.tar.gz -C ${PS_INSTALL_FOLDER}
-
-# ------ Second stage ------
-# Start a new stage so we lose all the tar.gz layers from the final image
-FROM ${imageRepo}:${fromTag}  
-
-# Copy only the files we need from the previous stage
-COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
 # Define Args and Env needed to create links
 ARG PS_INSTALL_VERSION=6
@@ -43,27 +22,22 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     LANG=en_US.UTF-8
 
 # Install dependencies and clean up
-RUN dnf install -y \
-        libicu \
-        openssl-libs \
+RUN dnf install -y /tmp/powershell.rpm \
+    && dnf install -y \
 	# less is needed for help
 	less \
-        \
-        # Needed to run localdef
+    # Needed to run localdef
         glibc-locale-source \
-        \
-        # Invoke-WebRequest doesn't work correctly without this
+    # Invoke-WebRequest doesn't work correctly without this
         compat-openssl10 \
     && dnf upgrade-minimal -y --security \
     && dnf clean all \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \
-    \
-    # Create the pwsh symbolic link that points to powershell
-    && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh
+    # remove powershell package
+    && rm /tmp/powershell.rpm
 
 # Define args needed only for the labels
 ARG VCS_REF="none"
-ARG PS_VERSION=6.1.0
 ARG IMAGE_NAME=mcr.microsoft.com/powershell:fedora28
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/release/stable/fedora28/docker/Dockerfile
+++ b/release/stable/fedora28/docker/Dockerfile
@@ -12,12 +12,8 @@ ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$
 # downoad the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
-# Define Args and Env needed to create links
-ARG PS_INSTALL_VERSION=6
-ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
-    \
-    # Define ENVs for Localization/Globalization
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8
 

--- a/release/stable/ubuntu16.04/docker/Dockerfile
+++ b/release/stable/ubuntu16.04/docker/Dockerfile
@@ -1,12 +1,42 @@
 # Docker image file that describes an Ubuntu16.04 image with PowerShell installed from Microsoft APT Repo
 ARG fromTag=16.04
+ARG imageRepo=ubuntu
 
-FROM ubuntu:${fromTag}
+FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.1.0
-ARG PS_VERSION_POSTFIX=-1.ubuntu.16.04
-ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu16.04
+ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.16.04_amd64.deb
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+
+RUN echo ${PS_PACKAGE_URL}
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
+
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
+# Install dependencies and clean up
+RUN apt-get update \
+    && apt install -y /tmp/powershell.deb \
+    && apt-get install -y \
+    # less is required for help in powershell
+        less \
+    # requied to setup the locale
+        locales \
+    # required for SSL
+        ca-certificates \
+    && apt-get dist-upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && locale-gen $LANG && update-locale \
+    # remove powershell package
+    && rm /tmp/powershell.deb
+
+# Define args needed only for the labels
 ARG VCS_REF="none"
+ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu16.04
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" \
@@ -16,43 +46,13 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell-Docker" \
       org.label-schema.name="powershell" \
       org.label-schema.vendor="PowerShell" \
-      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.version=${PS_VERSION} \
       org.label-schema.schema-version="1.0" \
+      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.docker.cmd="docker run ${IMAGE_NAME} pwsh -c '$psversiontable'" \
       org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" \
       org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" \
       org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
-
-# Install dependencies and clean up
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        apt-utils \
-        ca-certificates \
-        apt-transport-https \
-        locales \
-        less \
-    && apt-get dist-upgrade -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Setup the locale
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
-RUN locale-gen $LANG && update-locale
-
-# Download the Microsoft repository GPG keys
-ADD https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb .
-
-# Register the Microsoft repository GPG keys
-RUN dpkg -i packages-microsoft-prod.deb
-
-# Install powershell from Microsoft Repo
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    powershell=${PS_VERSION}${PS_VERSION_POSTFIX} \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 # Use PowerShell as the default shell
 # Use array to avoid Docker prepending /bin/sh -c

--- a/release/stable/ubuntu18.04/docker/Dockerfile
+++ b/release/stable/ubuntu18.04/docker/Dockerfile
@@ -1,12 +1,42 @@
 # Docker image file that describes an Ubuntu18.04 image with PowerShell installed from Microsoft APT Repo
 ARG fromTag=18.04
+ARG imageRepo=ubuntu
 
-FROM ubuntu:${fromTag}
+FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.1.0
-ARG PS_VERSION_POSTFIX=-1.ubuntu.18.04
-ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu18.04
+ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.18.04_amd64.deb
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+
+RUN echo ${PS_PACKAGE_URL}
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
+
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
+# Install dependencies and clean up
+RUN apt-get update \
+    && apt-get install -y /tmp/powershell.deb \
+    && apt-get install -y \
+    # less is required for help in powershell
+        less \
+    # requied to setup the locale
+        locales \
+    # required for SSL
+        ca-certificates \
+    && apt-get dist-upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && locale-gen $LANG && update-locale \
+    # remove powershell package
+    && rm /tmp/powershell.deb
+
+# Define args needed only for the labels
 ARG VCS_REF="none"
+ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu18.04
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" \
@@ -16,47 +46,13 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell-Docker" \
       org.label-schema.name="powershell" \
       org.label-schema.vendor="PowerShell" \
-      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.version=${PS_VERSION} \
       org.label-schema.schema-version="1.0" \
+      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.docker.cmd="docker run ${IMAGE_NAME} pwsh -c '$psversiontable'" \
       org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" \
       org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" \
       org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
-
-# setup terminal
-ENV TERM xterm
-
-# Install dependencies and clean up
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        apt-utils \
-        ca-certificates \
-        apt-transport-https \
-        locales \
-        gnupg2 \
-        less \
-    && apt-get dist-upgrade -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Setup the locale
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
-RUN locale-gen $LANG && update-locale
-
-# Download the Microsoft repository GPG keys
-ADD https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb .
-
-# Register the Microsoft repository GPG keys
-RUN dpkg -i packages-microsoft-prod.deb
-
-# Install powershell from Microsoft Repo
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    powershell=${PS_VERSION}${PS_VERSION_POSTFIX} \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 # Use PowerShell as the default shell
 # Use array to avoid Docker prepending /bin/sh -c

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -27,7 +27,7 @@ phases:
   parameters:
     name: ubuntu1804
     imagename: ubuntu18.04
-    stable: false
+    stable: true
     servicing: false
 
 - template: .vsts-ci/phase.yml
@@ -44,7 +44,7 @@ phases:
   parameters:
     name: fedora28
     imagename: fedora28
-    stable: false
+    stable: true
     servicing: false
 
 - template: .vsts-ci/phase.yml


### PR DESCRIPTION
## PR Summary

Make images use package files from Github
  - Stable and Servicing RedHat variants 
  - All preview images are blocked due to inconsistency with the package name
  - Enable CI for Stable Ubuntu 18.04 and Fedora 28

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
  - **OR**
    - [ ] Update [README.powershell.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershell.md)
    - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
