### PR TITLE
Make Ubuntu 14.04 stable and servicing to using packages download instead of packages.microsoft.com

### DIFF
--- a/release/preview/alpine/docker/Dockerfile
+++ b/release/preview/alpine/docker/Dockerfile
@@ -16,7 +16,7 @@ ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-x64.tar.gz
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=6-preview
 
-# downoad the Linux tar.gz and save it
+# Download the Linux tar.gz and save it
 ADD ${PS_PACKAGE_URL} /tmp/linux.tar.gz
 
 # define the folder we will be installing PowerShell to

--- a/release/servicing/centos7/docker/Dockerfile
+++ b/release/servicing/centos7/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
 # Define ENVs for Localization/Globalization

--- a/release/servicing/fedora27/docker/Dockerfile
+++ b/release/servicing/fedora27/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
 # Define ENVs for Localization/Globalization

--- a/release/servicing/ubuntu14.04/docker/Dockerfile
+++ b/release/servicing/ubuntu14.04/docker/Dockerfile
@@ -1,12 +1,51 @@
 # Docker image file that describes an Ubuntu14.04 image with PowerShell installed from Microsoft APT Repo
 ARG fromTag=14.04
+ARG imageRepo=ubuntu
 
-FROM ubuntu:${fromTag}
+FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.0.4
-ARG PS_VERSION_POSTFIX=-1.ubuntu.14.04
-ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu14.04
+ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.14.04_amd64.deb
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+
+RUN echo ${PS_PACKAGE_URL}
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
+
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
+# Install dependencies and clean up
+RUN apt-get update \
+    && apt-get install -y \
+    # less is required for help in powershell
+        less \
+    # requied to setup the locale
+        locales \
+    # required for SSL
+        ca-certificates \
+    # simplifies deb file install
+        gdebi \
+    && gdebi --n /tmp/powershell.deb \
+    # gdebi isn't needed anymore remove it
+    && apt-get purge -y gdebi \
+    # remove any unused dependecies
+    && apt-get autoremove -y \
+    # upgrade all packages
+    && apt-get dist-upgrade -y \
+    # clean the cache
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    # generate the locales
+    && locale-gen $LANG && update-locale \
+    # remove powershell package
+    && rm /tmp/powershell.deb
+
+# Define args needed only for the labels
 ARG VCS_REF="none"
+ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu14.04
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" \
@@ -17,41 +56,12 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       org.label-schema.name="powershell" \
       org.label-schema.vendor="PowerShell" \
       org.label-schema.version=${PS_VERSION} \
-      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.schema-version="1.0" \
+      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.docker.cmd="docker run ${IMAGE_NAME} pwsh -c '$psversiontable'" \
       org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" \
       org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" \
       org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
-
-# Setup the locale
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
-RUN locale-gen $LANG && update-locale
-
-# Install dependencies and clean up
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        apt-utils \
-        ca-certificates \
-        apt-transport-https \
-        less \
-    && apt-get dist-upgrade -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Download the Microsoft repository GPG keys
-ADD https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb .
-
-# Register the Microsoft repository GPG keys
-RUN dpkg -i packages-microsoft-prod.deb
-
-# Install powershell from Microsoft Repo
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-	powershell=${PS_VERSION}${PS_VERSION_POSTFIX} \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 # Use PowerShell as the default shell
 # Use array to avoid Docker prepending /bin/sh -c

--- a/release/servicing/ubuntu14.04/docker/Dockerfile
+++ b/release/servicing/ubuntu14.04/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.14.04_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 RUN echo ${PS_PACKAGE_URL}
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
 
 # Define ENVs for Localization/Globalization

--- a/release/servicing/ubuntu16.04/docker/Dockerfile
+++ b/release/servicing/ubuntu16.04/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.16.04_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 RUN echo ${PS_PACKAGE_URL}
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
 
 # Define ENVs for Localization/Globalization

--- a/release/stable/alpine/docker/Dockerfile
+++ b/release/stable/alpine/docker/Dockerfile
@@ -18,7 +18,7 @@ ARG PS_PACKAGE_MUSL=powershell-${PS_VERSION}-linux-musl-x64.tar.gz
 ARG PS_PACKAGE_MUSL_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE_MUSL}
 ARG PS_INSTALL_VERSION=6
 
-# downoad the Linux tar.gz and save it
+# Download the Linux tar.gz and save it
 ADD ${PS_PACKAGE_URL} /tmp/linux.tar.gz
 
 # define the folder we will be installing PowerShell to

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG PS_VERSION=6.1.0
 ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
 # Define ENVs for Localization/Globalization

--- a/release/stable/fedora27/docker/Dockerfile
+++ b/release/stable/fedora27/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
 # Define ENVs for Localization/Globalization

--- a/release/stable/fedora28/docker/Dockerfile
+++ b/release/stable/fedora28/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
 
 # Define ENVs for Localization/Globalization

--- a/release/stable/opensuse423/docker/Dockerfile
+++ b/release/stable/opensuse423/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN zypper --non-interactive update --skip-interactive
 RUN zypper --non-interactive install \
         tar
 
-# downoad the Linux tar.gz and save it
+# Download the Linux tar.gz and save it
 ADD ${PS_PACKAGE_URL} /tmp/linux.tar.gz
 
 # Unzip the Linux tar.gz

--- a/release/stable/ubuntu14.04/docker/Dockerfile
+++ b/release/stable/ubuntu14.04/docker/Dockerfile
@@ -1,12 +1,51 @@
 # Docker image file that describes an Ubuntu14.04 image with PowerShell installed from Microsoft APT Repo
 ARG fromTag=14.04
+ARG imageRepo=ubuntu
 
-FROM ubuntu:${fromTag}
+FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.1.0
-ARG PS_VERSION_POSTFIX=-1.ubuntu.14.04
-ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu14.04
+ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.14.04_amd64.deb
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+
+RUN echo ${PS_PACKAGE_URL}
+# downoad the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
+
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
+# Install dependencies and clean up
+RUN apt-get update \
+    && apt-get install -y \
+    # less is required for help in powershell
+        less \
+    # requied to setup the locale
+        locales \
+    # required for SSL
+        ca-certificates \
+    # simplifies deb file install
+        gdebi \
+    && gdebi --n /tmp/powershell.deb \
+    # gdebi isn't needed anymore remove it
+    && apt-get purge -y gdebi \
+    # remove any unused dependecies
+    && apt-get autoremove -y \
+    # upgrade all packages
+    && apt-get dist-upgrade -y \
+    # clean the cache
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    # generate the locales
+    && locale-gen $LANG && update-locale \
+    # remove powershell package
+    && rm /tmp/powershell.deb
+
+# Define args needed only for the labels
 ARG VCS_REF="none"
+ARG IMAGE_NAME=mcr.microsoft.com/powershell:ubuntu14.04
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" \
@@ -17,41 +56,12 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       org.label-schema.name="powershell" \
       org.label-schema.vendor="PowerShell" \
       org.label-schema.version=${PS_VERSION} \
-      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.schema-version="1.0" \
+      org.label-schema.vcs-ref=${VCS_REF} \
       org.label-schema.docker.cmd="docker run ${IMAGE_NAME} pwsh -c '$psversiontable'" \
       org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" \
       org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" \
       org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
-
-# Setup the locale
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
-RUN locale-gen $LANG && update-locale
-
-# Install dependencies and clean up
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        apt-utils \
-        ca-certificates \
-        apt-transport-https \
-        less \
-    && apt-get dist-upgrade -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Download the Microsoft repository GPG keys
-ADD https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb .
-
-# Register the Microsoft repository GPG keys
-RUN dpkg -i packages-microsoft-prod.deb
-
-# Install powershell from Microsoft Repo
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-	powershell=${PS_VERSION}${PS_VERSION_POSTFIX} \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 # Use PowerShell as the default shell
 # Use array to avoid Docker prepending /bin/sh -c

--- a/release/stable/ubuntu14.04/docker/Dockerfile
+++ b/release/stable/ubuntu14.04/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.14.04_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 RUN echo ${PS_PACKAGE_URL}
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
 
 # Define ENVs for Localization/Globalization

--- a/release/stable/ubuntu16.04/docker/Dockerfile
+++ b/release/stable/ubuntu16.04/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.16.04_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 RUN echo ${PS_PACKAGE_URL}
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
 
 # Define ENVs for Localization/Globalization

--- a/release/stable/ubuntu18.04/docker/Dockerfile
+++ b/release/stable/ubuntu18.04/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PS_PACKAGE=powershell_${PS_VERSION}-1.ubuntu.18.04_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 RUN echo ${PS_PACKAGE_URL}
-# downoad the Linux package and save it
+# Download the Linux package and save it
 ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
 
 # Define ENVs for Localization/Globalization


### PR DESCRIPTION
## PR Summary

Make Ubuntu 14.04 stable and servicing to using packages download instead of packages.microsoft.com

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
  - **OR**
    - [ ] Update [README.powershell.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershell.md)
    - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
