### PR TITLE
Make Debian 8 and 9 to using packages download instead of packages.microsoft.com

### DIFF
--- a/release/stable/debian8/docker/Dockerfile
+++ b/release/stable/debian8/docker/Dockerfile
@@ -1,40 +1,54 @@
 # Docker image file that describes an Debian 8 image with PowerShell installed from Microsoft APT Repo
 ARG fromTag=jessie
+ARG imageRepo=debian
 
-FROM debian:${fromTag}
+
+FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.1.0
-ARG PS_VERSION_POSTFIX=-1.debian.8
-ARG IMAGE_NAME=mcr.microsoft.com/powershell:debian-jessie
-ARG VCS_REF="none"
+ARG PS_PACKAGE=powershell_${PS_VERSION}-1.debian.8_amd64.deb
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-# Install dependencies
+RUN echo ${PS_PACKAGE_URL}
+# Download the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
+
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    # required to remove gdebi on debian 8
+    SUDO_FORCE_REMOVE=yes
+
+# Install dependencies and clean up
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        apt-utils \
-        ca-certificates \
-        curl \
-        apt-transport-https \
+    && apt-get install -y \
+    # less is required for help in powershell
+        less \
+    # requied to setup the locale
         locales \
-        less
-
-# Setup the locale
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
-RUN locale-gen $LANG && update-locale
-
-# Import the public repository GPG keys
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-
-# Register the Microsoft Product feed
-RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/microsoft.list
-
-# Install powershell from Microsoft Repo
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-	powershell=${PS_VERSION}${PS_VERSION_POSTFIX} \
+    # required for SSL
+        ca-certificates \
+    # simplifies deb file install
+        gdebi \
+    && gdebi --n /tmp/powershell.deb \
+    # gdebi isn't needed anymore remove it
+    && apt-get purge -y gdebi \
+    # remove any unused dependecies
+    && apt-get autoremove -y \
+    # upgrade all packages
+    && apt-get dist-upgrade -y \
+    # clean the cache
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # generate the locales
+    && locale-gen $LANG && update-locale \
+    # remove powershell package
+    && rm /tmp/powershell.deb
+
+# Define args needed only for the labels
+ARG VCS_REF="none"
+ARG IMAGE_NAME=mcr.microsoft.com/powershell:debian-8
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" \

--- a/release/stable/debian9/docker/Dockerfile
+++ b/release/stable/debian9/docker/Dockerfile
@@ -1,41 +1,43 @@
 # Docker image file that describes an Debian 9 image with PowerShell installed from Microsoft APT Repo
 ARG fromTag=stretch
+ARG imageRepo=debian
 
-FROM debian:${fromTag}
+
+FROM ${imageRepo}:${fromTag} AS installer-env
 
 ARG PS_VERSION=6.1.0
-ARG PS_VERSION_POSTFIX=-1.debian.9
-ARG IMAGE_NAME=mcr.microsoft.com/powershell:debian-jessie
-ARG VCS_REF="none"
+ARG PS_PACKAGE=powershell_${PS_VERSION}-1.debian.9_amd64.deb
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-# Install dependencies
+RUN echo ${PS_PACKAGE_URL}
+# Download the Linux package and save it
+ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
+
+# Define ENVs for Localization/Globalization
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
+# Install dependencies and clean up
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        apt-utils \
-        ca-certificates \
-        curl \
-        apt-transport-https \
+    && apt install -y /tmp/powershell.deb \
+    && apt-get install -y \
+    # less is required for help in powershell
+        less \
+    # requied to setup the locale
         locales \
-        gnupg \
-        less
-
-# Setup the locale
-ENV LANG en_US.UTF-8
-ENV LC_ALL $LANG
-RUN locale-gen $LANG && update-locale
-
-# Import the public repository GPG keys
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-
-# Register the Microsoft Product feed
-RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list
-
-# Install powershell from Microsoft Repo
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-	powershell=${PS_VERSION}${PS_VERSION_POSTFIX} \
+    # required for SSL
+        ca-certificates \
+    && apt-get dist-upgrade -y \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && locale-gen $LANG && update-locale \
+    # remove powershell package
+    && rm /tmp/powershell.deb
+
+# Define args needed only for the labels
+ARG VCS_REF="none"
+ARG IMAGE_NAME=mcr.microsoft.com/powershell:debian-9
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" \

--- a/tests/containerTestCommon.psm1
+++ b/tests/containerTestCommon.psm1
@@ -63,10 +63,11 @@ function Invoke-Docker
     }
     elseif($dockerExitCode -ne 0 -and $FailureAction -eq 'error')
     {
+        $resultString = $result | out-string -Width 9999
         if($result.length -gt 80) 
         {
             $filename = [System.io.path]::GetTempFileName()
-            $result | Out-File -FilePath $filename
+            $resultString | Out-File -FilePath $filename
             if($env:TF_BUILD)
             {
                 if($env:BUILD_REASON -ne 'PullRequest')
@@ -79,7 +80,7 @@ function Invoke-Docker
         }
         else 
         {
-            Write-Error "docker $command failed with: $($result -join [Environment]::NewLine)  ($($result.length))" -ErrorAction Stop    
+            Write-Error "docker $command failed with: $resultString  ($($result.length))" -ErrorAction Stop    
         }
 
         return $false


### PR DESCRIPTION
## PR Summary

Make Debian 8 and 9 to using packages download instead of packages.microsoft.com

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
  - **OR**
    - [ ] Update [README.powershell.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershell.md)
    - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
