### PR TITLE
Fix RPM and nanoserver package formats

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -339,7 +339,16 @@ End {
                     if($SasUrl)
                     {
                         $packageUrl = [System.UriBuilder]::new($sasBase)
-                        $packageName = $meta.PackageFormat -replace '\${PS_VERSION}', $psversion
+                        $packageVersion = $psversion
+
+                        # if the package name ends with rpm
+                        # then replace the - in the filename with _ as fpm creates the packages this way.
+                        if($meta.PackageFormat -match 'rpm$')
+                        {
+                            $packageVersion = $packageVersion -replace '-', '_'
+                        }
+
+                        $packageName = $meta.PackageFormat -replace '\${PS_VERSION}', $packageVersion
                         $containerName = 'v' + ($psversion -replace '\.', '-') -replace '~', '-'
                         $packageUrl.Path = $packageUrl.Path + $containerName + '/' + $packageName
                         $packageUrl.Query = $sasQuery

--- a/build.ps1
+++ b/build.ps1
@@ -329,9 +329,19 @@ End {
                         $imageNameParam = 'pshorg/powershellcommunity:' + ($firstActualTag -split ':')[1]
                     }
 
+                    $packageVersion = $psversion
+
+                    # if the package name ends with rpm
+                    # then replace the - in the filename with _ as fpm creates the packages this way.
+                    if($meta.PackageFormat -match 'rpm$')
+                    {
+                        $packageVersion = $packageVersion -replace '-', '_'
+                    }
+
                     $buildArgs =  @{
                         fromTag = $fromTag
-                        PS_VERSION = $psversion
+                        PS_VERSION = $psVersion
+                        PACKAGE_VERSION = $packageVersion
                         VCS_REF = $vcf_ref
                         IMAGE_NAME = $imageNameParam
                     }
@@ -339,14 +349,6 @@ End {
                     if($SasUrl)
                     {
                         $packageUrl = [System.UriBuilder]::new($sasBase)
-                        $packageVersion = $psversion
-
-                        # if the package name ends with rpm
-                        # then replace the - in the filename with _ as fpm creates the packages this way.
-                        if($meta.PackageFormat -match 'rpm$')
-                        {
-                            $packageVersion = $packageVersion -replace '-', '_'
-                        }
 
                         $packageName = $meta.PackageFormat -replace '\${PS_VERSION}', $packageVersion
                         $containerName = 'v' + ($psversion -replace '\.', '-') -replace '~', '-'

--- a/release/preview/centos7/docker/Dockerfile
+++ b/release/preview/centos7/docker/Dockerfile
@@ -4,8 +4,9 @@ ARG imageRepo=centos
 
 FROM ${imageRepo}:${fromTag} AS installer-env
 
-ARG PS_VERSION=6.1.0~rc.1
-ARG PS_PACKAGE=powershell-preview-${PS_VERSION}-1.rhel.7.x86_64.rpm
+ARG PS_VERSION=6.2.0-preview.2
+ARG PACKAGE_VERSION=6.2.0_preview.2
+ARG PS_PACKAGE=powershell-preview-${PACKAGE_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 # Download the Linux package and save it

--- a/release/preview/fedora27/docker/Dockerfile
+++ b/release/preview/fedora27/docker/Dockerfile
@@ -4,8 +4,9 @@ ARG imageRepo=fedora
 
 FROM ${imageRepo}:${fromTag} AS installer-env
 
-ARG PS_VERSION=6.1.0~rc.1
-ARG PS_PACKAGE=powershell-preview-${PS_VERSION}-1.rhel.7.x86_64.rpm
+ARG PS_VERSION=6.2.0-preview.2
+ARG PACKAGE_VERSION=6.2.0_preview.2
+ARG PS_PACKAGE=powershell-preview-${PACKAGE_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 

--- a/release/preview/fedora28/docker/Dockerfile
+++ b/release/preview/fedora28/docker/Dockerfile
@@ -4,8 +4,9 @@ ARG imageRepo=fedora
 
 FROM ${imageRepo}:${fromTag} AS installer-env
 
-ARG PS_VERSION=6.1.0~rc.1
-ARG PS_PACKAGE=powershell-preview-${PS_VERSION}-1.rhel.7.x86_64.rpm
+ARG PS_VERSION=6.2.0-preview.2
+ARG PACKAGE_VERSION=6.2.0_preview.2
+ARG PS_PACKAGE=powershell-preview-${PACKAGE_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 

--- a/release/preview/nanoserver/meta.json
+++ b/release/preview/nanoserver/meta.json
@@ -1,4 +1,4 @@
 {
     "IsLinux" : false,
-    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.msi"
+    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip"
 }

--- a/release/servicing/nanoserver/meta.json
+++ b/release/servicing/nanoserver/meta.json
@@ -1,4 +1,4 @@
 {
     "IsLinux" : false,
-    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.msi"
+    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip"
 }

--- a/release/stable/nanoserver/meta.json
+++ b/release/stable/nanoserver/meta.json
@@ -1,4 +1,4 @@
 {
     "IsLinux" : false,
-    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.msi"
+    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip"
 }

--- a/tests/container.tests.ps1
+++ b/tests/container.tests.ps1
@@ -187,9 +187,10 @@ Describe "Linux Containers" -Tags 'Behavior', 'Linux' {
             $actualVersion = Get-ContainerPowerShellVersion -TestContext $testContext -Name $Name
             switch -Regex ($Name)
             {
-                '6\.\d\.0\-\w+\.1\-alpine' {
+                '6\.\d\.0\-\w+\.[12]\-alpine' {
                     # 6.1.0-rc.1-alpine was published with 6.1.0-fixalpine as the version
                     # 6.2.0-preview.1-alpine was published with 6.1.0 as the version
+                    # 6.2.0-preview.2-alpine was published with 6.1.0 as the version
                     $actualVersion | Should -Match '^6\.1\.0(\-fixalpine)?$'
                 }
                 default {


### PR DESCRIPTION
## PR Summary

Fix RPM and NanoServer package formats
  - RPM has an underscore after the version number if it is a preview
  - NanoServer uses a zip and not MSI

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershell.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershell.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
