### PR TITLE
Fix build issues caused by a bad getTags script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -265,7 +265,7 @@ End {
         }
 
         # Get the tag data for the image
-        $tagData = & $scriptPath -CI:$CI.IsPresent
+        $tagData = @(& $scriptPath -CI:$CI.IsPresent | Where-Object {$_.FromTag})
 
         if (!$ShortTag) {
             foreach ($tagGroup in ($tagData | Group-Object -Property 'FromTag')) {

--- a/release/community-stable/amazonlinux/getLatestTag.ps1
+++ b/release/community-stable/amazonlinux/getLatestTag.ps1
@@ -4,11 +4,11 @@
 # return objects representing the tags we need to base the kali image on
 
 # The versions of photon we care about
-$shortTags = @('2.0-20181010')
+$shortTags = @('2.0')
 
 $parent = Join-Path -Path $PSScriptRoot -ChildPath '..'
 $repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath '..'
 $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath
 
-Get-DockerTags -ShortTags $shortTags -Image "amazonlinux" -FullTagFilter '^2.0-\d{8}$' -OnlyShortTags
+Get-DockerTags -ShortTags $shortTags -Image "amazonlinux" -FullTagFilter '^2\.0\.\d{8}(\.\d*)?$'


### PR DESCRIPTION
## PR Summary

Fix build issues caused by a bad getTags script
  - fix the build script to warn when it gets a missing fullTag in a get tags result
  - fix the amazonlinux image to correctly return tags

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershell.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershell.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
