### PR TITLE
Update manifest for 1809

### DIFF
--- a/.vsts-ci/phase.yml
+++ b/.vsts-ci/phase.yml
@@ -8,11 +8,13 @@ parameters:
   communityStable: 'false'
   communityPreview: 'false'
   communityServicing: 'false'
+  continueonerror: 'false'
 
 phases:
 - phase: ${{ parameters.name }}
   variables:
     ImageName: ${{ parameters.imagename }}
+    ContinueOnError: ${{ parameters.continueonerror }}
 
   queue: ${{ parameters.queue }}
   steps:
@@ -24,35 +26,42 @@ phases:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'stable' -TestLogPostfix '$(ImageName)-stable'
       displayName: $(ImageName) Stable
       condition: succeededOrFailed()
+      continueOnError: $(ContinueOnError)
 
   - ${{ if eq(parameters.preview, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'preview' -TestLogPostfix '$(ImageName)-preview'
       displayName: $(ImageName) Preview
       condition: succeededOrFailed()
+      continueOnError: $(ContinueOnError)
 
   - ${{ if eq(parameters.servicing, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'servicing' -TestLogPostfix '$(ImageName)-servicing'
       displayName: $(ImageName) Servicing
       condition: succeededOrFailed()
+      continueOnError: $(ContinueOnError)
 
   - ${{ if eq(parameters.communityStable, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'community-stable' -TestLogPostfix '$(ImageName)-stable'
       displayName: $(ImageName) Stable
       condition: succeededOrFailed()
+      continueOnError: $(ContinueOnError)
 
   - ${{ if eq(parameters.communityPreview, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'community-preview' -TestLogPostfix '$(ImageName)-preview'
       displayName: $(ImageName) Preview
       condition: succeededOrFailed()
+      continueOnError: $(ContinueOnError)
 
   - ${{ if eq(parameters.communityServicing, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'community-servicing' -TestLogPostfix '$(ImageName)-servicing'
       displayName: $(ImageName) Servicing
       condition: succeededOrFailed()
+      continueOnError: $(ContinueOnError)
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()
     displayName: Publish $(ImageName) Test Results **\test*.xml
+    continueOnError: $(ContinueOnError)
     inputs:
       testRunner: NUnit
       testResultsFiles: '**\test*.xml'

--- a/.vsts-ci/phase.yml
+++ b/.vsts-ci/phase.yml
@@ -8,7 +8,7 @@ parameters:
   communityStable: 'false'
   communityPreview: 'false'
   communityServicing: 'false'
-  continueonerror: 'false'
+  continueonerror: false
 
 phases:
 - phase: ${{ parameters.name }}
@@ -26,42 +26,42 @@ phases:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'stable' -TestLogPostfix '$(ImageName)-stable'
       displayName: $(ImageName) Stable
       condition: succeededOrFailed()
-      continueOnError: $(ContinueOnError)
+      continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.preview, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'preview' -TestLogPostfix '$(ImageName)-preview'
       displayName: $(ImageName) Preview
       condition: succeededOrFailed()
-      continueOnError: $(ContinueOnError)
+      continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.servicing, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'servicing' -TestLogPostfix '$(ImageName)-servicing'
       displayName: $(ImageName) Servicing
       condition: succeededOrFailed()
-      continueOnError: $(ContinueOnError)
+      continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.communityStable, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'community-stable' -TestLogPostfix '$(ImageName)-stable'
       displayName: $(ImageName) Stable
       condition: succeededOrFailed()
-      continueOnError: $(ContinueOnError)
+      continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.communityPreview, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'community-preview' -TestLogPostfix '$(ImageName)-preview'
       displayName: $(ImageName) Preview
       condition: succeededOrFailed()
-      continueOnError: $(ContinueOnError)
+      continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.communityServicing, 'true') }}:
     - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'community-servicing' -TestLogPostfix '$(ImageName)-servicing'
       displayName: $(ImageName) Servicing
       condition: succeededOrFailed()
-      continueOnError: $(ContinueOnError)
+      continueOnError: ${{ parameters.continueonerror }}
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()
     displayName: Publish $(ImageName) Test Results **\test*.xml
-    continueOnError: $(ContinueOnError)
+    continueOnError: ${{ parameters.continueonerror }}
     inputs:
       testRunner: NUnit
       testResultsFiles: '**\test*.xml'

--- a/createAllManifests.ps1
+++ b/createAllManifests.ps1
@@ -20,22 +20,25 @@ $latestStableUbuntu   = "ubuntu-bionic"
 $latestStableWsc1709  = "windowsservercore-1709"
 $latestStableWscLtsc  = "windowsservercore-latest"
 $latestStableWsc1803  = "windowsservercore-1803"
+$latestStableWsc1809  = "windowsservercore-1809"
 $latestStableNano1709 = "nanoserver-1709"
 $latestStableNano1803 = "nanoserver-1803"
+$latestStableNano1809 = "nanoserver-1809"
 
 $latestPreviewUbuntu   = "preview-ubuntu-bionic"
 $latestPreviewWsc1709  = "preview-windowsservercore-1709"
 $latestPreviewWscLtsc  = "preview-windowsservercore-latest"
 $latestPreviewWsc1803  = "preview-windowsservercore-1803"
+$latestPreviewWsc1809  = "preview-windowsservercore-1809"
 
 switch ($Channel)
 {
     'preview' {
-        &$createScriptPath -ContainerRegistry $Registry -taglist $latestPreviewUbuntu, $latestPreviewWsc1709, $latestPreviewWscLtsc, $latestPreviewWsc1803  -ManifestTag 'preview'
+        &$createScriptPath -ContainerRegistry $Registry -taglist $latestPreviewUbuntu, $latestPreviewWsc1709, $latestPreviewWscLtsc, $latestPreviewWsc1803, $latestPreviewWsc1809  -ManifestTag 'preview'
     }
 
     'stable' {
-        &$createScriptPath -ContainerRegistry $Registry -taglist $latestStableUbuntu, $latestStableWsc1709, $latestStableWscLtsc, $latestStableWsc1803  -ManifestTag 'latest'
-        &$createScriptPath -ContainerRegistry $Registry -taglist $latestStableNano1709, $latestStableNano1803  -ManifestTag 'nanoserver'
+        &$createScriptPath -ContainerRegistry $Registry -taglist $latestStableUbuntu, $latestStableWsc1709, $latestStableWscLtsc, $latestStableWsc1803, $latestStableWsc1809 -ManifestTag 'latest'
+        &$createScriptPath -ContainerRegistry $Registry -taglist $latestStableNano1709, $latestStableNano1803, $latestStableNano1809 -ManifestTag 'nanoserver'
     }
 }

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -96,6 +96,7 @@ phases:
     servicing: false
     preview: false
     communityStable: true
+    continueonerror: true
 
 - template: .vsts-ci/phase.yml
   parameters:

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -105,6 +105,8 @@ phases:
     servicing: false
     preview: false
     communityStable: true
+    continueonerror: true
+
 
 - template: .vsts-ci/phase.yml
   parameters:
@@ -141,6 +143,7 @@ phases:
     servicing: false
     preview: false
     communityStable: true
+    continueonerror: true
 
 - template: .vsts-ci/phase.yml
   parameters:
@@ -150,7 +153,7 @@ phases:
     servicing: false
     preview: false
     communityStable: true
-    
+
 # Use CI switch to disable 1709 and 1803 builds because the VSTS hosted instances don't yet support 1709 or 1803
 # Skipping previews on windows due to how long it takes to build on windows
 - template: .vsts-ci/phase.yml


### PR DESCRIPTION
## PR Summary

Update manifest for 1809
  - manifests are `preview`, `latest` and `nanoserver`
  - Also, add the ability to specify that some phases can just ignore all errors to temporarily deal with #112 and #113

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
