### PR TITLE
fix issue where release build URLs are not calculated correctly

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -346,14 +346,14 @@ End {
                         {
                             $packageUrl = [System.UriBuilder]::new($sasBase)
 
-                            $packageName = $meta.PackageFormat -replace '\${PS_VERSION}', $packageVersion
                             $previewTag = ''
                             if($actualChannel -like '*preview*')
                             {
                                 $previewTag = '-preview'
                             }
 
-                            $packageName = $meta.PackageFormat -replace '\${previewTag}', $previewTag
+                            $packageName = $meta.PackageFormat -replace '\${PS_VERSION}', $packageVersion
+                            $packageName = $packageName -replace '\${previewTag}', $previewTag
                             $containerName = 'v' + ($psversion -replace '\.', '-') -replace '~', '-'
                             $packageUrl.Path = $packageUrl.Path + $containerName + '/' + $packageName
                             $packageUrl.Query = $sasQuery


### PR DESCRIPTION
## PR Summary

fix issue where release build URLs are not calculated correctly
 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
