### PR TITLE
Add know issue metadata to allow skipping from tags which we know don't work

### DIFF
--- a/.vsts-ci/phase.yml
+++ b/.vsts-ci/phase.yml
@@ -23,37 +23,37 @@ phases:
     condition: succeededOrFailed()
 
   - ${{ if eq(parameters.stable, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'stable' -TestLogPostfix '$(ImageName)-stable'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnownIssues -Channel 'stable' -TestLogPostfix '$(ImageName)-stable'
       displayName: $(ImageName) Stable
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.preview, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'preview' -TestLogPostfix '$(ImageName)-preview'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnownIssues -Channel 'preview' -TestLogPostfix '$(ImageName)-preview'
       displayName: $(ImageName) Preview
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.servicing, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'servicing' -TestLogPostfix '$(ImageName)-servicing'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnownIssues -Channel 'servicing' -TestLogPostfix '$(ImageName)-servicing'
       displayName: $(ImageName) Servicing
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.communityStable, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'community-stable' -TestLogPostfix '$(ImageName)-stable'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnownIssues -Channel 'community-stable' -TestLogPostfix '$(ImageName)-stable'
       displayName: $(ImageName) Stable
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.communityPreview, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'community-preview' -TestLogPostfix '$(ImageName)-preview'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnownIssues -Channel 'community-preview' -TestLogPostfix '$(ImageName)-preview'
       displayName: $(ImageName) Preview
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.communityServicing, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'community-servicing' -TestLogPostfix '$(ImageName)-servicing'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnownIssues -Channel 'community-servicing' -TestLogPostfix '$(ImageName)-servicing'
       displayName: $(ImageName) Servicing
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}

--- a/.vsts-ci/phase.yml
+++ b/.vsts-ci/phase.yml
@@ -23,37 +23,37 @@ phases:
     condition: succeededOrFailed()
 
   - ${{ if eq(parameters.stable, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'stable' -TestLogPostfix '$(ImageName)-stable'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'stable' -TestLogPostfix '$(ImageName)-stable'
       displayName: $(ImageName) Stable
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.preview, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'preview' -TestLogPostfix '$(ImageName)-preview'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'preview' -TestLogPostfix '$(ImageName)-preview'
       displayName: $(ImageName) Preview
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.servicing, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'servicing' -TestLogPostfix '$(ImageName)-servicing'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'servicing' -TestLogPostfix '$(ImageName)-servicing'
       displayName: $(ImageName) Servicing
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.communityStable, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'community-stable' -TestLogPostfix '$(ImageName)-stable'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'community-stable' -TestLogPostfix '$(ImageName)-stable'
       displayName: $(ImageName) Stable
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.communityPreview, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'community-preview' -TestLogPostfix '$(ImageName)-preview'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'community-preview' -TestLogPostfix '$(ImageName)-preview'
       displayName: $(ImageName) Preview
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}
 
   - ${{ if eq(parameters.communityServicing, 'true') }}:
-    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -Channel 'community-servicing' -TestLogPostfix '$(ImageName)-servicing'
+    - powershell: ./build.ps1 -build -name '$(ImageName)' -CI -IncludeKnowIssues -Channel 'community-servicing' -TestLogPostfix '$(ImageName)-servicing'
       displayName: $(ImageName) Servicing
       condition: succeededOrFailed()
       continueOnError: ${{ parameters.continueonerror }}

--- a/build.ps1
+++ b/build.ps1
@@ -89,7 +89,10 @@ param(
     [Parameter(ParameterSetName="localBuildAll")]
     [ValidatePattern('(\d+\.){2}\d(-\w+(\.\d+)?)?')]
     [string]
-    $Version
+    $Version,
+
+    [switch]
+    $IncludeKnownIssues
 )
 
 DynamicParam {
@@ -247,8 +250,15 @@ End {
                 continue
             }
 
-            $tagsTemplates = Get-Content -Path $tagsJsonPath | ConvertFrom-Json
             $meta = Get-DockerImageMetaData -Path $metaJsonPath
+            if($meta.tagTemplates.count -gt 0)
+            {
+                $tagsTemplates = $meta.tagTemplates
+            }
+            else
+            {
+                $tagsTemplates = Get-Content -Path $tagsJsonPath | ConvertFrom-Json
+            }
 
             $psversion = $windowsVersion
             if($meta.ShouldUseLinuxVersion())
@@ -256,159 +266,171 @@ End {
                 $psversion = $linuxVersion
             }
 
-            # Get the tag data for the image
-            $tagData = @(& $scriptPath -CI:$CI.IsPresent | Where-Object {$_.FromTag})
+            $getTagsExtraParams = @{}
 
-            if (!$ShortTag) {
-                foreach ($tagGroup in ($tagData | Group-Object -Property 'FromTag')) {
-                    $actualTags = @()
-                    $tagList = @()
-                    foreach($tag in $tagGroup.Group) {
-                        foreach ($tagTemplate in $tagsTemplates) {
-                            # replace the tag token with the tag
-                            if ($tagTemplate -match '#tag#') {
-                                $actualTag = $tagTemplate -replace '#tag#', $tag.Tag
-                            }
-                            elseif ($tagTemplate -match '#shorttag#' -and $tag.Type -eq 'Short') {
-                                $actualTag = $tagTemplate -replace '#shorttag#', $tag.Tag
-                            }
-                            elseif ($tagTemplate -match '#fulltag#' -and $tag.Type -eq 'Full') {
-                                $actualTag = $tagTemplate -replace '#fulltag#', $tag.Tag
-                            }
-                            else {
-                                # skip if the type of tag token doesn't match the type of tag
-                                Write-Verbose -Message "Skipping $($tag.Tag) - $tagTemplate, token doesn't match template"
-                                continue
-                            }
-
-                            # Replace the the psversion token with the powershell version in the tag
-                            $actualVersion = $windowsVersion
-                            $actualTag = $actualTag -replace '#psversion#', $actualVersion
-                            $actualTag = $actualTag.ToLowerInvariant()
-                            $actualTags += "${ImageName}:$actualTag"
-                            $tagList += $actualTag
-                            $fromTag = $Tag.FromTag
-                        }
-                    }
-
-                    $firstActualTag = $actualTags[0]
-                    $firstActualTagOnly = $tagList[0]
-
-                    if ($Build.IsPresent -or $Test.IsPresent)
+            if($meta.ShortTags.count -gt 0)
+            {
+                $shortTags = @()
+                foreach ($shortTag in $meta.ShortTags) {
+                    if(!$shortTag.KnownIssue -or $IncludeKnownIssues.IsPresent)
                     {
-                        Write-Verbose -Message "Adding the following to the list to be tested, fromTag: $fromTag Tag: $actualTag PSversion: $psversion" -Verbose
-                        $contextPath = Join-Path -Path $imagePath -ChildPath 'docker'
-                        $vcf_ref = git rev-parse --short HEAD
-                        $script:ErrorActionPreference = 'stop'
-                        $testsPath = Join-Path -Path $PSScriptRoot -ChildPath 'tests'
-                        Import-Module (Join-Path -Path $testsPath -ChildPath 'containerTestCommon.psm1') -Force
-                        if ($meta.IsLinux) {
-                            $os = 'linux'
+                        $shortTags += $shortTag.Tag
+                    }
+                }
+
+                $getTagsExtraParams.Add('ShortTags',$shortTags)
+            }
+            # Get the tag data for the image
+            $tagData = @(& $scriptPath -CI:$CI.IsPresent @getTagsExtraParams | Where-Object {$_.FromTag})
+
+            foreach ($tagGroup in ($tagData | Group-Object -Property 'FromTag')) {
+                $actualTags = @()
+                $tagList = @()
+                foreach($tag in $tagGroup.Group) {
+                    foreach ($tagTemplate in $tagsTemplates) {
+                        # replace the tag token with the tag
+                        if ($tagTemplate -match '#tag#') {
+                            $actualTag = $tagTemplate -replace '#tag#', $tag.Tag
+                        }
+                        elseif ($tagTemplate -match '#shorttag#' -and $tag.Type -eq 'Short') {
+                            $actualTag = $tagTemplate -replace '#shorttag#', $tag.Tag
+                        }
+                        elseif ($tagTemplate -match '#fulltag#' -and $tag.Type -eq 'Full') {
+                            $actualTag = $tagTemplate -replace '#fulltag#', $tag.Tag
                         }
                         else {
-                            $os = 'windows'
+                            # skip if the type of tag token doesn't match the type of tag
+                            Write-Verbose -Message "Skipping $($tag.Tag) - $tagTemplate, token doesn't match template"
+                            continue
                         }
 
-                        $skipVerification = $false
-                        if($dockerFileName -eq 'nanoserver' -and $CI.IsPresent)
-                        {
-                            Write-Verbose -Message "Skipping verification of $firstActualTagOnly in CI because the CI system only supports LTSC and at least 1709 is required." -Verbose
-                            # The version of nanoserver in CI doesn't have all the changes needed to verify the image
-                            $skipVerification = $true
-                        }
-
-                        # for the image name label, always use the official image name
-                        $imageNameParam = 'mcr.microsoft.com/powershell:' + $firstActualTagOnly
-                        if($actualChannel -like 'community-*')
-                        {
-                            # use the image name for pshorg for community images
-                            $imageNameParam = 'pshorg/powershellcommunity:' + $firstActualTagOnly
-                        }
-
-                        $packageVersion = $psversion
-
-                        # if the package name ends with rpm
-                        # then replace the - in the filename with _ as fpm creates the packages this way.
-                        if($meta.PackageFormat -match 'rpm$')
-                        {
-                            $packageVersion = $packageVersion -replace '-', '_'
-                        }
-
-                        $buildArgs =  @{
-                                fromTag = $fromTag
-                                PS_VERSION = $psVersion
-                                PACKAGE_VERSION = $packageVersion
-                                VCS_REF = $vcf_ref
-                                IMAGE_NAME = $imageNameParam
-                            }
-
-                        if($SasUrl)
-                        {
-                            $packageUrl = [System.UriBuilder]::new($sasBase)
-
-                            $previewTag = ''
-                            if($actualChannel -like '*preview*')
-                            {
-                                $previewTag = '-preview'
-                            }
-
-                            $packageName = $meta.PackageFormat -replace '\${PS_VERSION}', $packageVersion
-                            $packageName = $packageName -replace '\${previewTag}', $previewTag
-                            $containerName = 'v' + ($psversion -replace '\.', '-') -replace '~', '-'
-                            $packageUrl.Path = $packageUrl.Path + $containerName + '/' + $packageName
-                            $packageUrl.Query = $sasQuery
-                            $buildArgs.Add('PS_PACKAGE_URL', $packageUrl.ToString())
-                        }
-
-                        $testArgs = @{
-                            tags = $actualTags
-                            BuildArgs = $buildArgs
-                            ContextPath = $contextPath
-                            OS = $os
-                            ExpectedVersion = $actualVersion
-                            SkipVerification = $skipVerification
-                            SkipWebCmdletTests = $meta.SkipWebCmdletTests
-                        }
-
-                        $testArgList += $testArgs
-                        $localImageNames += $firstActualTag
+                        # Replace the the psversion token with the powershell version in the tag
+                        $actualVersion = $windowsVersion
+                        $actualTag = $actualTag -replace '#psversion#', $actualVersion
+                        $actualTag = $actualTag.ToLowerInvariant()
+                        $actualTags += "${ImageName}:$actualTag"
+                        $tagList += $actualTag
+                        $fromTag = $Tag.FromTag
                     }
-                    elseif ($GetTags.IsPresent) {
-                        Write-Verbose "from: $fromTag actual: $($actualTags -join ', ') psversion: $psversion" -Verbose
+                }
+
+                $firstActualTag = $actualTags[0]
+                $firstActualTagOnly = $tagList[0]
+
+                if ($Build.IsPresent -or $Test.IsPresent)
+                {
+                    Write-Verbose -Message "Adding the following to the list to be tested, fromTag: $fromTag Tag: $actualTag PSversion: $psversion" -Verbose
+                    $contextPath = Join-Path -Path $imagePath -ChildPath 'docker'
+                    $vcf_ref = git rev-parse --short HEAD
+                    $script:ErrorActionPreference = 'stop'
+                    $testsPath = Join-Path -Path $PSScriptRoot -ChildPath 'tests'
+                    Import-Module (Join-Path -Path $testsPath -ChildPath 'containerTestCommon.psm1') -Force
+                    if ($meta.IsLinux) {
+                        $os = 'linux'
                     }
-                    elseif ($GenerateTagsYaml.IsPresent) {
-                        $tagGroup = 'public/powershell'
+                    else {
                         $os = 'windows'
-                        if($meta.IsLinux)
+                    }
+
+                    $skipVerification = $false
+                    if($dockerFileName -eq 'nanoserver' -and $CI.IsPresent)
+                    {
+                        Write-Verbose -Message "Skipping verification of $firstActualTagOnly in CI because the CI system only supports LTSC and at least 1709 is required." -Verbose
+                        # The version of nanoserver in CI doesn't have all the changes needed to verify the image
+                        $skipVerification = $true
+                    }
+
+                    # for the image name label, always use the official image name
+                    $imageNameParam = 'mcr.microsoft.com/powershell:' + $firstActualTagOnly
+                    if($actualChannel -like 'community-*')
+                    {
+                        # use the image name for pshorg for community images
+                        $imageNameParam = 'pshorg/powershellcommunity:' + $firstActualTagOnly
+                    }
+
+                    $packageVersion = $psversion
+
+                    # if the package name ends with rpm
+                    # then replace the - in the filename with _ as fpm creates the packages this way.
+                    if($meta.PackageFormat -match 'rpm$')
+                    {
+                        $packageVersion = $packageVersion -replace '-', '_'
+                    }
+
+                    $buildArgs =  @{
+                            fromTag = $fromTag
+                            PS_VERSION = $psVersion
+                            PACKAGE_VERSION = $packageVersion
+                            VCS_REF = $vcf_ref
+                            IMAGE_NAME = $imageNameParam
+                        }
+
+                    if($SasUrl)
+                    {
+                        $packageUrl = [System.UriBuilder]::new($sasBase)
+
+                        $previewTag = ''
+                        if($actualChannel -like '*preview*')
                         {
-                            $os = 'linux'
+                            $previewTag = '-preview'
                         }
-                        $architecture = 'amd64'
-                        $dockerfile = "https://github.com/PowerShell/PowerShell-Docker/blob/master/release/$actualChannel/$dockerFileName/docker/Dockerfile"
 
-                        $osVersion = $meta.osVersion
-                        if($osVersion)
+                        $packageName = $meta.PackageFormat -replace '\${PS_VERSION}', $packageVersion
+                        $packageName = $packageName -replace '\${previewTag}', $previewTag
+                        $containerName = 'v' + ($psversion -replace '\.', '-') -replace '~', '-'
+                        $packageUrl.Path = $packageUrl.Path + $containerName + '/' + $packageName
+                        $packageUrl.Query = $sasQuery
+                        $buildArgs.Add('PS_PACKAGE_URL', $packageUrl.ToString())
+                    }
+
+                    $testArgs = @{
+                        tags = $actualTags
+                        BuildArgs = $buildArgs
+                        ContextPath = $contextPath
+                        OS = $os
+                        ExpectedVersion = $actualVersion
+                        SkipVerification = $skipVerification
+                        SkipWebCmdletTests = $meta.SkipWebCmdletTests
+                    }
+
+                    $testArgList += $testArgs
+                    $localImageNames += $firstActualTag
+                }
+                elseif ($GetTags.IsPresent) {
+                    Write-Verbose "from: $fromTag actual: $($actualTags -join ', ') psversion: $psversion" -Verbose
+                }
+                elseif ($GenerateTagsYaml.IsPresent) {
+                    $tagGroup = 'public/powershell'
+                    $os = 'windows'
+                    if($meta.IsLinux)
+                    {
+                        $os = 'linux'
+                    }
+                    $architecture = 'amd64'
+                    $dockerfile = "https://github.com/PowerShell/PowerShell-Docker/blob/master/release/$actualChannel/$dockerFileName/docker/Dockerfile"
+
+                    $osVersion = $meta.osVersion
+                    if($osVersion)
+                    {
+                        $osVersion = $osVersion.replace('${fromTag}',$fromTag)
+
+                        if(!$tagGroups.ContainsKey($tagGroup))
                         {
-                            $osVersion = $osVersion.replace('${fromTag}',$fromTag)
-
-                            if(!$tagGroups.ContainsKey($tagGroup))
-                            {
-                                $tags = @()
-                                $tagGroups[$tagGroup] = $tags
-                            }
-                            $tag = [PSCustomObject]@{
-                                Architecture = $architecture
-                                OsVersion = $osVersion
-                                Os = $os
-                                Tags = $tagList
-                                Dockerfile = $dockerfile
-                            }
-
-                            $tagGroups[$tagGroup] += $tag
+                            $tags = @()
+                            $tagGroups[$tagGroup] = $tags
                         }
-                        else {
-                            Write-Verbose "Skipping $firstActualTagOnly due to no OS Version in meta.json" -Verbose
+                        $tag = [PSCustomObject]@{
+                            Architecture = $architecture
+                            OsVersion = $osVersion
+                            Os = $os
+                            Tags = $tagList
+                            Dockerfile = $dockerfile
                         }
+
+                        $tagGroups[$tagGroup] += $tag
+                    }
+                    else {
+                        Write-Verbose "Skipping $firstActualTagOnly due to no OS Version in meta.json" -Verbose
                     }
                 }
             }

--- a/release/preview/nanoserver/meta.json
+++ b/release/preview/nanoserver/meta.json
@@ -1,5 +1,17 @@
 {
     "IsLinux" : false,
     "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
-    "osVersion": "Nano Server, version ${fromTag}"
+    "osVersion": "Nano Server, version ${fromTag}",
+    "shortTags": [
+        {"Tag": "1709"},
+        {"Tag": "1803"},
+        {
+            "Tag": "1809",
+            "KnownIssue": true
+        }
+    ],
+    "tagTemplates": [
+        "#psversion#-nanoserver-#tag#",
+        "preview-nanoserver-#shorttag#"
+    ]
 }

--- a/release/preview/nanoserver/tags.json
+++ b/release/preview/nanoserver/tags.json
@@ -1,4 +1,0 @@
-[
-    "#psversion#-nanoserver-#tag#",
-    "preview-nanoserver-#shorttag#"
-]

--- a/release/servicing/nanoserver/meta.json
+++ b/release/servicing/nanoserver/meta.json
@@ -1,4 +1,15 @@
 {
     "IsLinux" : false,
-    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip"
+    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
+    "shortTags": [
+        {"Tag": "1709"},
+        {"Tag": "1803"},
+        {
+            "Tag": "1809",
+            "KnownIssue": true
+        }
+    ],
+    "tagTemplates": [
+        "#psversion#-nanoserver-#tag#"
+    ]
 }

--- a/release/servicing/nanoserver/tags.json
+++ b/release/servicing/nanoserver/tags.json
@@ -1,3 +1,0 @@
-[
-    "#psversion#-nanoserver-#tag#"
-]

--- a/release/stable/nanoserver/getLatestTag.ps1
+++ b/release/stable/nanoserver/getLatestTag.ps1
@@ -6,16 +6,16 @@
 
 param(
     [Switch]
-    $CI
+    $CI,
+    # The versions of nanoserver we care about
+    [string[]]
+    $ShortTags
 )
 
 $parent = Join-Path -Path $PSScriptRoot -ChildPath '..'
 $repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath '..'
 $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath
-
-# The versions of nanoserver we care about
-$shortTags = @('1709','1803','1809')
 
 if(!$CI.IsPresent)
 {

--- a/release/stable/nanoserver/meta.json
+++ b/release/stable/nanoserver/meta.json
@@ -1,5 +1,17 @@
 {
     "IsLinux" : false,
     "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
-    "osVersion": "Nano Server, version ${fromTag}"
+    "osVersion": "Nano Server, version ${fromTag}",
+    "shortTags": [
+        {"Tag": "1709"},
+        {"Tag": "1803"},
+        {
+            "Tag": "1809",
+            "KnownIssue": true
+        }
+    ],
+    "tagTemplates": [
+        "#psversion#-nanoserver-#tag#",
+        "nanoserver-#shorttag#"
+    ]
 }

--- a/release/stable/nanoserver/tags.json
+++ b/release/stable/nanoserver/tags.json
@@ -1,4 +1,0 @@
-[
-    "#psversion#-nanoserver-#tag#",
-    "nanoserver-#shorttag#"
-]

--- a/tools/buildHelper/buildHelper.psm1
+++ b/tools/buildHelper/buildHelper.psm1
@@ -134,6 +134,17 @@ class DockerImageMetaData {
 
     [string]
     $TagGroup = 'Linux'
+
+    [ShortTagMetaData[]]
+    $ShortTags
+
+    [string[]]
+    $tagTemplates
+}
+
+class ShortTagMetaData {
+    [string] $Tag
+    [Bool] $KnownIssue
 }
 
 Function Get-DockerImageMetaData


### PR DESCRIPTION
## PR Summary

Add know issue metadata to allow skipping from tags which we know don't work
  - Also, allow `tags.json` to be moved into `meta.json`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [x] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
