### PR TITLE
Separate `nanoserver 1809` due to breaking change

### DIFF
--- a/release/preview/nanoserver/getLatestTag.ps1
+++ b/release/preview/nanoserver/getLatestTag.ps1
@@ -6,16 +6,16 @@
 
 param(
     [Switch]
-    $CI
+    $CI,
+    # The versions of nanoserver we care about
+    [string[]]
+    $ShortTags
 )
 
 $parent = Join-Path -Path $PSScriptRoot -ChildPath '..'
 $repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath '..'
 $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath
-
-# The versions of nanoserver we care about
-$shortTags = @('1709','1803','1809')
 
 if(!$CI.IsPresent)
 {

--- a/release/preview/nanoserver/getLatestTag.ps1
+++ b/release/preview/nanoserver/getLatestTag.ps1
@@ -19,7 +19,7 @@ $shortTags = @('1709','1803','1809')
 
 if(!$CI.IsPresent)
 {
-    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}' -Mcr
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}(_amd64)?$' -Mcr
 }
 else {
     # This is not supported for nanoserver so don't build in production but try building it as a CI test for the Dockerfile

--- a/release/preview/nanoserver/meta.json
+++ b/release/preview/nanoserver/meta.json
@@ -4,11 +4,7 @@
     "osVersion": "Nano Server, version ${fromTag}",
     "shortTags": [
         {"Tag": "1709"},
-        {"Tag": "1803"},
-        {
-            "Tag": "1809",
-            "KnownIssue": true
-        }
+        {"Tag": "1803"}
     ],
     "tagTemplates": [
         "#psversion#-nanoserver-#tag#",

--- a/release/preview/nanoserver1809/docker/Dockerfile
+++ b/release/preview/nanoserver1809/docker/Dockerfile
@@ -1,0 +1,56 @@
+# escape=`
+# Args used by from statements must be defined here:
+ARG fromTag=1709
+ARG WindowsServerCoreVersion=latest
+ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
+ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
+
+# Use server core as an installer container to extract PowerShell,
+# As this is a multi-stage build, this stage will eventually be thrown away
+FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
+
+# Arguments for installing PowerShell, must be defined in the container they are used
+ARG PS_VERSION=6.1.0-rc.1
+
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN if (!($env:PS_VERSION -match '^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$' )) {throw ('PS_Version ({0}) must match the regex "^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$"' -f $env:PS_VERSION)}
+ADD ${PS_PACKAGE_URL} /powershell.zip
+
+RUN Expand-Archive powershell.zip -DestinationPath \PowerShell
+
+# Install PowerShell into NanoServer
+FROM ${NanoServerRepo}:${fromTag}
+
+ARG VCS_REF="none"
+ARG PS_VERSION=6.1.0-rc.1
+ARG IMAGE_NAME=mcr.microsoft.com/powershell
+
+LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `
+      readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" `
+      description="This Dockerfile will install the latest release of PowerShell." `
+      org.label-schema.usage="https://github.com/PowerShell/PowerShell/tree/master/docker#run-the-docker-image-you-built" `
+      org.label-schema.url="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" `
+      org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell-Docker" `
+      org.label-schema.name="powershell" `
+      org.label-schema.vcs-ref=${VCS_REF} `
+      org.label-schema.vendor="PowerShell" `
+      org.label-schema.version=${PS_VERSION} `
+      org.label-schema.schema-version="1.0" `
+      org.label-schema.docker.cmd="docker run ${IMAGE_NAME} pwsh -c '$psversiontable'" `
+      org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" `
+      org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" `
+      org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
+
+# Copy PowerShell Core from the installer container
+ENV ProgramFiles C:\Program Files
+COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell"]
+
+# Persist %PSCORE% ENV variable for user convenience
+ENV PSCORE="$ProgramFiles\PowerShell\pwsh.exe"
+# Set the path
+ENV PATH="$PATH;${ProgramFiles}\PowerShell"
+
+CMD ["pwsh.exe"]

--- a/release/preview/nanoserver1809/getLatestTag.ps1
+++ b/release/preview/nanoserver1809/getLatestTag.ps1
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# return objects representing the tags we need to base the nanoserver image on
+
+
+param(
+    [Switch]
+    $CI,
+    # The versions of nanoserver we care about
+    [string[]]
+    $ShortTags
+)
+
+$parent = Join-Path -Path $PSScriptRoot -ChildPath '..'
+$repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath '..'
+$modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
+Import-Module $modulePath
+
+if(!$CI.IsPresent)
+{
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}(_amd64)?$' -Mcr
+}
+else {
+    # This is not supported for nanoserver so don't build in production but try building it as a CI test for the Dockerfile
+    $shortTags = @('latest')
+
+    # The \d{4,} part of the regex is because the API is returning tags which are 3 digits and older than the 4 digit tags
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '10\.0\.14393\.\d{4,}$' -SkipShortTagFilter -Mcr
+}

--- a/release/preview/nanoserver1809/meta.json
+++ b/release/preview/nanoserver1809/meta.json
@@ -1,0 +1,12 @@
+{
+    "IsLinux" : false,
+    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
+    "osVersion": "Nano Server, version ${fromTag}",
+    "shortTags": [
+        {"Tag": "1809"}
+    ],
+    "tagTemplates": [
+        "#psversion#-nanoserver-#tag#",
+        "preview-nanoserver-#shorttag#"
+    ]
+}

--- a/release/servicing/nanoserver/docker/Dockerfile
+++ b/release/servicing/nanoserver/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
 # As this is a multi-stage build, this stage will eventually be thrown away
 FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
 
-# Arguments for installing powershell, must be defined in the container they are used
+# Arguments for installing PowerShell, must be defined in the container they are used
 ARG PS_VERSION=6.0.4
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
@@ -44,7 +44,7 @@ LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `
       org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" `
       org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
 
-# Copy Powershell Core from the installer containter
+# Copy PowerShell Core from the installer container
 ENV ProgramFiles C:\Program Files
 COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell"]
 

--- a/release/servicing/nanoserver/getLatestTag.ps1
+++ b/release/servicing/nanoserver/getLatestTag.ps1
@@ -6,7 +6,10 @@
 
 param(
     [Switch]
-    $CI
+    $CI,
+    # The versions of nanoserver we care about
+    [string[]]
+    $ShortTags
 )
 
 $parent = Join-Path -Path $PSScriptRoot -ChildPath '..'
@@ -14,17 +17,14 @@ $repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath
 $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath
 
-# The versions of nanoserver we care about
-$shortTags = @('1709','1803','1809')
-
 if(!$CI.IsPresent)
 {
-    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}(_amd64)?$'
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}(_amd64)?$' -Mcr
 }
 else {
     # This is not supported for nanoserver so don't build in production but try building it as a CI test for the Dockerfile
     $shortTags = @('latest')
 
     # The \d{4,} part of the regex is because the API is returning tags which are 3 digits and older than the 4 digit tags
-    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '10\.0\.14393\.\d{4,}$' -SkipShortTagFilter
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '10\.0\.14393\.\d{4,}$' -SkipShortTagFilter -Mcr
 }

--- a/release/servicing/nanoserver/getLatestTag.ps1
+++ b/release/servicing/nanoserver/getLatestTag.ps1
@@ -19,7 +19,7 @@ $shortTags = @('1709','1803','1809')
 
 if(!$CI.IsPresent)
 {
-    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}'
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}(_amd64)?$'
 }
 else {
     # This is not supported for nanoserver so don't build in production but try building it as a CI test for the Dockerfile

--- a/release/servicing/nanoserver/meta.json
+++ b/release/servicing/nanoserver/meta.json
@@ -1,13 +1,10 @@
 {
     "IsLinux" : false,
     "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
+    "osVersion": "Nano Server, version ${fromTag}",
     "shortTags": [
         {"Tag": "1709"},
-        {"Tag": "1803"},
-        {
-            "Tag": "1809",
-            "KnownIssue": true
-        }
+        {"Tag": "1803"}
     ],
     "tagTemplates": [
         "#psversion#-nanoserver-#tag#"

--- a/release/servicing/nanoserver1809/docker/Dockerfile
+++ b/release/servicing/nanoserver1809/docker/Dockerfile
@@ -1,0 +1,56 @@
+# escape=`
+# Args used by from statements must be defined here:
+ARG fromTag=1709
+ARG WindowsServerCoreVersion=latest
+ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
+ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
+
+# Use server core as an installer container to extract PowerShell,
+# As this is a multi-stage build, this stage will eventually be thrown away
+FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
+
+# Arguments for installing PowerShell, must be defined in the container they are used
+ARG PS_VERSION=6.0.4
+
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN if (!($env:PS_VERSION -match '^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$' )) {throw ('PS_Version ({0}) must match the regex "^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$"' -f $env:PS_VERSION)}
+ADD ${PS_PACKAGE_URL} /powershell.zip
+
+RUN Expand-Archive powershell.zip -DestinationPath \PowerShell
+
+# Install PowerShell into NanoServer
+FROM ${NanoServerRepo}:${fromTag}
+
+ARG VCS_REF="none"
+ARG PS_VERSION=6.0.4
+ARG IMAGE_NAME=mcr.microsoft.com/powershell
+
+LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `
+      readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" `
+      description="This Dockerfile will install the latest release of PowerShell." `
+      org.label-schema.usage="https://github.com/PowerShell/PowerShell/tree/master/docker#run-the-docker-image-you-built" `
+      org.label-schema.url="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" `
+      org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell-Docker" `
+      org.label-schema.name="powershell" `
+      org.label-schema.vcs-ref=${VCS_REF} `
+      org.label-schema.vendor="PowerShell" `
+      org.label-schema.version=${PS_VERSION} `
+      org.label-schema.schema-version="1.0" `
+      org.label-schema.docker.cmd="docker run ${IMAGE_NAME} pwsh -c '$psversiontable'" `
+      org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" `
+      org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" `
+      org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
+
+# Copy PowerShell Core from the installer container
+ENV ProgramFiles C:\Program Files
+COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell"]
+
+# Persist %PSCORE% ENV variable for user convenience
+ENV PSCORE="$ProgramFiles\PowerShell\pwsh.exe"
+# Set the path
+ENV PATH="$PATH;${ProgramFiles}\PowerShell"
+
+CMD ["pwsh.exe"]

--- a/release/servicing/nanoserver1809/getLatestTag.ps1
+++ b/release/servicing/nanoserver1809/getLatestTag.ps1
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# return objects representing the tags we need to base the nanoserver image on
+
+
+param(
+    [Switch]
+    $CI,
+    # The versions of nanoserver we care about
+    [string[]]
+    $ShortTags
+)
+
+$parent = Join-Path -Path $PSScriptRoot -ChildPath '..'
+$repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath '..'
+$modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
+Import-Module $modulePath
+
+if(!$CI.IsPresent)
+{
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}(_amd64)?$' -Mcr
+}
+else {
+    # This is not supported for nanoserver so don't build in production but try building it as a CI test for the Dockerfile
+    $shortTags = @('latest')
+
+    # The \d{4,} part of the regex is because the API is returning tags which are 3 digits and older than the 4 digit tags
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '10\.0\.14393\.\d{4,}$' -SkipShortTagFilter -Mcr
+}

--- a/release/servicing/nanoserver1809/meta.json
+++ b/release/servicing/nanoserver1809/meta.json
@@ -1,0 +1,11 @@
+{
+    "IsLinux" : false,
+    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
+    "osVersion": "Nano Server, version ${fromTag}",
+    "shortTags": [
+        {"Tag": "1809"}
+    ],
+    "tagTemplates": [
+        "#psversion#-nanoserver-#tag#"
+    ]
+}

--- a/release/stable/nanoserver/getLatestTag.ps1
+++ b/release/stable/nanoserver/getLatestTag.ps1
@@ -19,7 +19,7 @@ Import-Module $modulePath
 
 if(!$CI.IsPresent)
 {
-    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}' -Mcr
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}(_amd64)?$' -Mcr
 }
 else {
     # This is not supported for nanoserver so don't build in production but try building it as a CI test for the Dockerfile

--- a/release/stable/nanoserver/meta.json
+++ b/release/stable/nanoserver/meta.json
@@ -4,11 +4,7 @@
     "osVersion": "Nano Server, version ${fromTag}",
     "shortTags": [
         {"Tag": "1709"},
-        {"Tag": "1803"},
-        {
-            "Tag": "1809",
-            "KnownIssue": true
-        }
+        {"Tag": "1803"}
     ],
     "tagTemplates": [
         "#psversion#-nanoserver-#tag#",

--- a/release/stable/nanoserver1809/docker/Dockerfile
+++ b/release/stable/nanoserver1809/docker/Dockerfile
@@ -1,0 +1,56 @@
+# escape=`
+# Args used by from statements must be defined here:
+ARG fromTag=1709
+ARG WindowsServerCoreVersion=latest
+ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
+ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
+
+# Use server core as an installer container to extract PowerShell,
+# As this is a multi-stage build, this stage will eventually be thrown away
+FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
+
+# Arguments for installing PowerShell, must be defined in the container they are used
+ARG PS_VERSION=6.1.0
+
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN if (!($env:PS_VERSION -match '^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$' )) {throw ('PS_Version ({0}) must match the regex "^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$"' -f $env:PS_VERSION)}
+ADD ${PS_PACKAGE_URL} /powershell.zip
+
+RUN Expand-Archive powershell.zip -DestinationPath \PowerShell
+
+# Install PowerShell into NanoServer
+FROM ${NanoServerRepo}:${fromTag}
+
+ARG VCS_REF="none"
+ARG PS_VERSION=6.1.0
+ARG IMAGE_NAME=mcr.microsoft.com/powershell
+
+LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `
+      readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" `
+      description="This Dockerfile will install the latest release of PowerShell." `
+      org.label-schema.usage="https://github.com/PowerShell/PowerShell/tree/master/docker#run-the-docker-image-you-built" `
+      org.label-schema.url="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" `
+      org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell-Docker" `
+      org.label-schema.name="powershell" `
+      org.label-schema.vcs-ref=${VCS_REF} `
+      org.label-schema.vendor="PowerShell" `
+      org.label-schema.version=${PS_VERSION} `
+      org.label-schema.schema-version="1.0" `
+      org.label-schema.docker.cmd="docker run ${IMAGE_NAME} pwsh -c '$psversiontable'" `
+      org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" `
+      org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" `
+      org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help"
+
+# Copy PowerShell Core from the installer container
+ENV ProgramFiles C:\Program Files
+COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell"]
+
+# Persist %PSCORE% ENV variable for user convenience
+ENV PSCORE="$ProgramFiles\PowerShell\pwsh.exe"
+# Set the path
+ENV PATH="$PATH;${ProgramFiles}\PowerShell"
+
+CMD ["pwsh.exe"]

--- a/release/stable/nanoserver1809/getLatestTag.ps1
+++ b/release/stable/nanoserver1809/getLatestTag.ps1
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# return objects representing the tags we need to base the nanoserver image on
+
+
+param(
+    [Switch]
+    $CI,
+    # The versions of nanoserver we care about
+    [string[]]
+    $ShortTags
+)
+
+$parent = Join-Path -Path $PSScriptRoot -ChildPath '..'
+$repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath '..'
+$modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
+Import-Module $modulePath
+
+if(!$CI.IsPresent)
+{
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '\d{4}_KB\d{7}(_amd64)?$' -Mcr
+}
+else {
+    # This is not supported for nanoserver so don't build in production but try building it as a CI test for the Dockerfile
+    $shortTags = @('latest')
+
+    # The \d{4,} part of the regex is because the API is returning tags which are 3 digits and older than the 4 digit tags
+    Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/nanoserver" -FullTagFilter '10\.0\.14393\.\d{4,}$' -SkipShortTagFilter -Mcr
+}

--- a/release/stable/nanoserver1809/meta.json
+++ b/release/stable/nanoserver1809/meta.json
@@ -1,0 +1,12 @@
+{
+    "IsLinux" : false,
+    "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
+    "osVersion": "Nano Server, version ${fromTag}",
+    "shortTags": [
+        {"Tag": "1809"}
+    ],
+    "tagTemplates": [
+        "#psversion#-nanoserver-#tag#",
+        "nanoserver-#shorttag#"
+    ]
+}


### PR DESCRIPTION
## PR Summary

Separate `nanoserver 1809` due to breaking change
  - `SETX` no longer works to set environment variable so 1809 has to be separate at least from `1709` where `ENV` did not work for the `PATH` variable.
  - Also fix regex for `nanoserver` tag query

Fixes #89 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
