### PR TITLE
Change the short tag for Debian 9 to 9 instead of 8

### DIFF
--- a/release/preview/debian9/getLatestTag.ps1
+++ b/release/preview/debian9/getLatestTag.ps1
@@ -11,4 +11,4 @@ $repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath
 $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath
 
-Get-DockerTags -ShortTags $shortTags -Image "debian" -FullTagFilter 'stretch-\d{8}[\.\d{1}]?' -AlternativeShortTag '8'
+Get-DockerTags -ShortTags $shortTags -Image "debian" -FullTagFilter 'stretch-\d{8}[\.\d{1}]?' -AlternativeShortTag '9'

--- a/release/stable/debian9/getLatestTag.ps1
+++ b/release/stable/debian9/getLatestTag.ps1
@@ -11,4 +11,4 @@ $repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath
 $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath
 
-Get-DockerTags -ShortTags $shortTags -Image "debian" -FullTagFilter 'stretch-\d{8}[\.\d{1}]?' -AlternativeShortTag '8'
+Get-DockerTags -ShortTags $shortTags -Image "debian" -FullTagFilter 'stretch-\d{8}[\.\d{1}]?' -AlternativeShortTag '9'


### PR DESCRIPTION
## PR Summary

Change the short tag for Debian 9 to 9 instead of 8

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
