### PR TITLE
maybe fix clearlinux

### DIFF
--- a/release/community-stable/clearlinux/docker/Dockerfile
+++ b/release/community-stable/clearlinux/docker/Dockerfile
@@ -20,7 +20,7 @@ ARG PS_INSTALL_VERSION=6
 ADD ${PS_PACKAGE_URL} /tmp/powershell-linux.tar.gz
 
 # Define Args for the needed to add the package
-ARG GNU_LINUX_LESS_PACKAGE_URL=https://ftp.gnu.org/gnu/less/less-530.tar.gz
+ARG GNU_LINUX_LESS_PACKAGE_URL=http://ftp.gnu.org/gnu/less/less-530.tar.gz
 
 # Download the less tar.gz and save it
 ADD ${GNU_LINUX_LESS_PACKAGE_URL} /tmp/less.tar.gz


### PR DESCRIPTION
## PR Summary
if I remember correctly, gnu.org doesn't support https, and this may be the reason it is timing out
<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
