### PR TITLE
Fix Windows Pull test cases beforeAll variable initialization

### DIFF
--- a/tests/container.tests.ps1
+++ b/tests/container.tests.ps1
@@ -115,7 +115,7 @@ Describe "Pull Linux Containers" -Tags 'Linux', 'Pull' {
 
 Describe "Pull Windows Containers" -Tags 'Windows', 'Pull' {
     BeforeAll {
-        $buildTestCases = @()
+        $pullTestCases = @()
         $script:windowsContainerRunTests | ForEach-Object {
             $pullTestCases += @{
                 Name = $_.Name


### PR DESCRIPTION
## PR Summary

Fix Windows Pull test cases beforeAll variable initialization

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
