### PR TITLE
Set SkipWebCmdletTests to False

### DIFF
--- a/release/community-stable/clearlinux/docker/Dockerfile
+++ b/release/community-stable/clearlinux/docker/Dockerfile
@@ -35,8 +35,10 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
 
 # Installation
 RUN \
+    # generate trust store
+    clrtrust generate -f \
     # install dependencies
-    swupd bundle-add \
+    && swupd bundle-add \
       # required libstdc++.so.6
       # required bundle to make less executable
       os-core-dev \
@@ -77,8 +79,10 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=0
 
 RUN \
+    # generate trust store
+    clrtrust generate -f \
     # install dependencies
-    swupd bundle-add \
+    && swupd bundle-add \
       # required package for International Components for Unicode
       runtime-libs-boost \
     # Create the pwsh symbolic link that points to powershell

--- a/release/community-stable/clearlinux/meta.json
+++ b/release/community-stable/clearlinux/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "PackageFormat": "powershell-${PS_VERSION}-linux-x64.tar.gz",
     "SkipGssNtlmSspTests": true,
-    "SkipWebCmdletTests": true,
+    "SkipWebCmdletTests": false,
     "tagTemplates": [
         "#psversion#-clearlinux-#tag#",
         "clearlinux-#shorttag#"

--- a/release/community-stable/clearlinux/meta.json
+++ b/release/community-stable/clearlinux/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "PackageFormat": "powershell-${PS_VERSION}-linux-x64.tar.gz",
     "SkipGssNtlmSspTests": true,
-    "SkipWebCmdletTests": false,
+    "SkipWebCmdletTests": false, 
     "tagTemplates": [
         "#psversion#-clearlinux-#tag#",
         "clearlinux-#shorttag#"


### PR DESCRIPTION
## PR Summary

fixes #172 

- Set SkipWebCmdletTest to `false`

I ran the same Dockerfile locally and tested with the same Invoke-WebRequest command without issue but I do notice that the clearlinux container experiences timeout and retries during downloading of the required bundles from repository.

So let's retry again with the automation.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)