### PR TITLE
Download, install, and delete pwsh dist in the same layer to reduce final image size (RedHat family-only)

### DIFF
--- a/release/community-stable/amazonlinux/docker/Dockerfile
+++ b/release/community-stable/amazonlinux/docker/Dockerfile
@@ -19,9 +19,6 @@ ARG PS_INSTALL_VERSION=6
 # Define Args and Env needed to create links
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
 
-# Download the RHEL7 PowerShell Core package and save it
-ADD ${PS_PACKAGE_URL} /tmp/powershell-linux.rpm
-
 # Define Args and Env needed to create links
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     \
@@ -33,9 +30,9 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache
 
 # Installation
-RUN \
+RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell-linux.rpm \
     # install dependencies
-    yum install -y \
+    && yum install -y \
 	    # required for help in PowerShell
 	    less \
 	    # NTLM remoting

--- a/release/community-stable/oraclelinux/docker/Dockerfile
+++ b/release/community-stable/oraclelinux/docker/Dockerfile
@@ -19,9 +19,6 @@ ARG PS_INSTALL_VERSION=6
 # Define Args and Env needed to create links
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
 
-# Download the RHEL7 PowerShell Core package and save it
-ADD ${PS_PACKAGE_URL} /tmp/powershell-linux.rpm
-
 # Define Args and Env needed to create links
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     \
@@ -33,9 +30,9 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache
 
 # Installation
-RUN \
+RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell-linux.rpm \
     # install dependencies
-    yum install -y \
+    && yum install -y \
 	    # required for help in powershell
 	    less \
 	    epel-release \

--- a/release/preview/centos7/docker/Dockerfile
+++ b/release/preview/centos7/docker/Dockerfile
@@ -9,9 +9,6 @@ ARG PACKAGE_VERSION=6.2.0_preview.2
 ARG PS_PACKAGE=powershell-preview-${PACKAGE_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-# Download the Linux package and save it
-ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
-
 # Define ENVs for Localization/Globalization
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
@@ -20,7 +17,8 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache
 
 # Install dependencies and clean up
-RUN yum install -y /tmp/powershell.rpm \
+RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
+    && yum install -y /tmp/powershell.rpm \
     # Required for gssntlmssp
     && yum install -y epel-release \
     # Update now that we have epel-release

--- a/release/preview/fedora28/docker/Dockerfile
+++ b/release/preview/fedora28/docker/Dockerfile
@@ -9,10 +9,6 @@ ARG PACKAGE_VERSION=6.2.0_preview.2
 ARG PS_PACKAGE=powershell-preview-${PACKAGE_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-
-# Download the Linux package and save it
-ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
-
 # Define ENVs for Localization/Globalization
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
@@ -21,7 +17,8 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache
 
 # Install dependencies and clean up
-RUN dnf install -y /tmp/powershell.rpm \
+RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
+    && dnf install -y /tmp/powershell.rpm \
     && dnf install -y \
 	# less is needed for help
 	less \

--- a/release/servicing/centos7/docker/Dockerfile
+++ b/release/servicing/centos7/docker/Dockerfile
@@ -9,9 +9,6 @@ ARG PACKAGE_VERSION=6.1.1
 ARG PS_PACKAGE=powershell-${PACKAGE_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-# Download the Linux package and save it
-ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
-
 # Define ENVs for Localization/Globalization
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
@@ -20,7 +17,8 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache
 
 # Install dependencies and clean up
-RUN yum install -y /tmp/powershell.rpm \
+RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
+    && yum install -y /tmp/powershell.rpm \
     # Required for gssntlmssp
     && yum install -y epel-release \
     # Update now that we have epel-release

--- a/release/servicing/fedora28/docker/Dockerfile
+++ b/release/servicing/fedora28/docker/Dockerfile
@@ -8,10 +8,6 @@ ARG PS_VERSION=6.1.0
 ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-
-# Download the Linux package and save it
-ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
-
 # Define ENVs for Localization/Globalization
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
@@ -20,7 +16,8 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache
 
 # Install dependencies and clean up
-RUN dnf install -y /tmp/powershell.rpm \
+RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
+    && dnf install -y /tmp/powershell.rpm \
     && dnf install -y \
 	# less is needed for help
 	less \

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -9,9 +9,6 @@ ARG PACKAGE_VERSION=6.2.0
 ARG PS_PACKAGE=powershell-${PACKAGE_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-# Download the Linux package and save it
-ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
-
 # Define ENVs for Localization/Globalization
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
@@ -20,7 +17,8 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache
 
 # Install dependencies and clean up
-RUN yum install -y /tmp/powershell.rpm \
+RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
+    && yum install -y /tmp/powershell.rpm \
     # Required for gssntlmssp
     && yum install -y epel-release \
     # Update now that we have epel-release

--- a/release/stable/fedora28/docker/Dockerfile
+++ b/release/stable/fedora28/docker/Dockerfile
@@ -8,10 +8,6 @@ ARG PS_VERSION=6.2.0
 ARG PS_PACKAGE=powershell-${PS_VERSION}-1.rhel.7.x86_64.rpm
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
-
-# Download the Linux package and save it
-ADD ${PS_PACKAGE_URL} /tmp/powershell.rpm
-
 # Define ENVs for Localization/Globalization
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LC_ALL=en_US.UTF-8 \
@@ -20,7 +16,8 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache
 
 # Install dependencies and clean up
-RUN dnf install -y /tmp/powershell.rpm \
+RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
+    && dnf install -y /tmp/powershell.rpm \
     && dnf install -y \
 	# less is needed for help
 	less \


### PR DESCRIPTION
## PR Summary

This patch uses the included curl on RedHat-based distro images to download PowerShell in the same layer it's installed in. This slices off one layer from the resulting images and saves ~50 MB (the size of the PowerShell dist package) on final image size.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
