### PR TITLE
Add `tar` to the test dependencies

### DIFF
--- a/release/community-stable/amazonlinux/test-deps/docker/Dockerfile
+++ b/release/community-stable/amazonlinux/test-deps/docker/Dockerfile
@@ -18,6 +18,11 @@ RUN \
       sudo \
       # add su
       util-linux \
+      iputils \
+      hostname \
+      procps \
+      wget \
+      openssl \
     && yum clean all \
     # remove cache folders and files
     && rm -rf /var/cache/yum

--- a/release/community-stable/amazonlinux/test-deps/docker/Dockerfile
+++ b/release/community-stable/amazonlinux/test-deps/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN \
       procps \
       wget \
       openssl \
+      tar \
     && yum clean all \
     # remove cache folders and files
     && rm -rf /var/cache/yum

--- a/release/preview/alpine/test-deps/docker/Dockerfile
+++ b/release/preview/alpine/test-deps/docker/Dockerfile
@@ -17,7 +17,12 @@ COPY --from=node /usr/local/bin/node /usr/local/bin/node
 COPY --from=node /opt/yarn-v${YARN_VERSION} /opt/yarn-v${YARN_VERSION}
 
 RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam \
-    && apk add bash sudo shadow \
+    && apk add \
+        bash \
+        sudo \
+        shadow \
+        openssl \
+        curl \
     && apk del .pipeline-deps \
     && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
     && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/release/preview/centos7/docker/Dockerfile
+++ b/release/preview/centos7/docker/Dockerfile
@@ -24,9 +24,12 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     # Update now that we have epel-release
     && yum update -y \
     # Install libraries for NTLM support
-    && yum install -y gssntlmssp \
-    # less is required for help in powershell
-    less \
+    && yum install -y \
+      gssntlmssp \
+      # less is required for help in powershell
+      less \
+      ca-certificates \
+      openssl \
     && yum upgrade-minimal -y --security \
     && yum clean all \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \

--- a/release/preview/centos7/docker/Dockerfile
+++ b/release/preview/centos7/docker/Dockerfile
@@ -28,8 +28,6 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
       gssntlmssp \
       # less is required for help in powershell
       less \
-      ca-certificates \
-      openssl \
     && yum upgrade-minimal -y --security \
     && yum clean all \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \

--- a/release/preview/centos7/test-deps/docker/Dockerfile
+++ b/release/preview/centos7/test-deps/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM ${BaseImage}
 RUN yum install -y \
         sudo \
         wget \
+        openssl \
     && yum clean all
 
 # Define args needed only for the labels

--- a/release/preview/centos7/test-deps/docker/Dockerfile
+++ b/release/preview/centos7/test-deps/docker/Dockerfile
@@ -4,7 +4,9 @@ ARG BaseImage=mcr.microsoft.com/powershell:centos-7
 FROM ${BaseImage}
 
 # Install dependencies and clean up
-RUN yum install -y sudo \
+RUN yum install -y \
+        sudo \
+        wget \
     && yum clean all
 
 # Define args needed only for the labels

--- a/release/preview/debian9/test-deps/docker/Dockerfile
+++ b/release/preview/debian9/test-deps/docker/Dockerfile
@@ -7,6 +7,11 @@ FROM ${BaseImage}
 RUN apt-get update \
     && apt-get install -y \
         sudo \
+        curl \
+        wget \
+        iputils-ping \
+        iputils-tracepath \
+        procps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/release/preview/fedora28/docker/Dockerfile
+++ b/release/preview/fedora28/docker/Dockerfile
@@ -20,13 +20,14 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     && dnf install -y /tmp/powershell.rpm \
     && dnf install -y \
-	# less is needed for help
-	less \
+    # less is needed for help
+    less \
     # Needed to run localdef
         glibc-locale-source \
     # Invoke-WebRequest doesn't work correctly without this
-        compat-openssl10 \
-	gssntlmssp \
+    compat-openssl10 \
+    ca-certificates \
+    gssntlmssp \
     && dnf upgrade-minimal -y --security \
     && dnf clean all \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \

--- a/release/preview/fedora28/test-deps/docker/Dockerfile
+++ b/release/preview/fedora28/test-deps/docker/Dockerfile
@@ -4,7 +4,13 @@ ARG BaseImage=mcr.microsoft.com/powershell:fedora-28
 FROM ${BaseImage}
 
 # Install dependencies and clean up
-RUN dnf install -y sudo \
+RUN dnf install -y \
+        sudo \
+        findutils \
+        hostname \
+        iputils \
+        wget \
+        procps-ng \
     && dnf clean all
 
 # Define args needed only for the labels

--- a/release/preview/opensuse423/test-deps/docker/Dockerfile
+++ b/release/preview/opensuse423/test-deps/docker/Dockerfile
@@ -8,6 +8,9 @@ RUN zypper --non-interactive update --skip-interactive \
     && zypper --non-interactive install \
          sudo \
          tar \
+         curl \
+         wget \
+         hostname \
     # clean package manager cache
     && zypper clean -a \
     # remove package manager log file

--- a/release/preview/opensuse423/test-deps/docker/Dockerfile
+++ b/release/preview/opensuse423/test-deps/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM ${BaseImage}
 RUN zypper --non-interactive update --skip-interactive \
     && zypper --non-interactive install \
          sudo \
+         tar \
     # clean package manager cache
     && zypper clean -a \
     # remove package manager log file

--- a/release/preview/ubuntu16.04/test-deps/docker/Dockerfile
+++ b/release/preview/ubuntu16.04/test-deps/docker/Dockerfile
@@ -7,6 +7,10 @@ FROM ${BaseImage}
 RUN apt-get update \
     && apt-get install -y \
         sudo \
+        curl \
+        wget \
+        iputils-ping \
+        iputils-tracepath \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/release/preview/ubuntu18.04/test-deps/docker/Dockerfile
+++ b/release/preview/ubuntu18.04/test-deps/docker/Dockerfile
@@ -7,6 +7,10 @@ FROM ${BaseImage}
 RUN apt-get update \
     && apt-get install -y \
         sudo \
+        curl \
+        wget \
+        iputils-ping \
+        iputils-tracepath \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/release/stable/alpine/test-deps/docker/Dockerfile
+++ b/release/stable/alpine/test-deps/docker/Dockerfile
@@ -17,7 +17,12 @@ COPY --from=node /usr/local/bin/node /usr/local/bin/node
 COPY --from=node /opt/yarn-v${YARN_VERSION} /opt/yarn-v${YARN_VERSION}
 
 RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam \
-    && apk add bash sudo shadow \
+    && apk add \
+        bash \
+        sudo \
+        shadow \
+        openssl \
+        curl \
     && apk del .pipeline-deps \
     && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
     && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -24,9 +24,12 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     # Update now that we have epel-release
     && yum update -y \
     # Install libraries for NTLM support
-    && yum install -y gssntlmssp \
-    # less is required for help in powershell
-    less \
+    && yum install -y \
+      gssntlmssp \
+      # less is required for help in powershell
+      less \
+      ca-certificates \
+      openssl \
     && yum upgrade-minimal -y --security \
     && yum clean all \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -28,8 +28,6 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
       gssntlmssp \
       # less is required for help in powershell
       less \
-      ca-certificates \
-      openssl \
     && yum upgrade-minimal -y --security \
     && yum clean all \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \

--- a/release/stable/centos7/test-deps/docker/Dockerfile
+++ b/release/stable/centos7/test-deps/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM ${BaseImage}
 RUN yum install -y \
         sudo \
         wget \
+        openssl \
     && yum clean all
 
 # Define args needed only for the labels

--- a/release/stable/centos7/test-deps/docker/Dockerfile
+++ b/release/stable/centos7/test-deps/docker/Dockerfile
@@ -4,7 +4,9 @@ ARG BaseImage=mcr.microsoft.com/powershell:centos-7
 FROM ${BaseImage}
 
 # Install dependencies and clean up
-RUN yum install -y sudo \
+RUN yum install -y \
+        sudo \
+        wget \
     && yum clean all
 
 # Define args needed only for the labels

--- a/release/stable/debian9/test-deps/docker/Dockerfile
+++ b/release/stable/debian9/test-deps/docker/Dockerfile
@@ -7,6 +7,11 @@ FROM ${BaseImage}
 RUN apt-get update \
     && apt-get install -y \
         sudo \
+        curl \
+        wget \
+        iputils-ping \
+        iputils-tracepath \
+        procps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/release/stable/fedora28/test-deps/docker/Dockerfile
+++ b/release/stable/fedora28/test-deps/docker/Dockerfile
@@ -4,7 +4,13 @@ ARG BaseImage=mcr.microsoft.com/powershell:fedora-28
 FROM ${BaseImage}
 
 # Install dependencies and clean up
-RUN dnf install -y sudo \
+RUN dnf install -y \
+        sudo \
+        findutils \
+        hostname \
+        iputils \
+        wget \
+        procps-ng \
     && dnf clean all
 
 # Define args needed only for the labels

--- a/release/stable/opensuse423/test-deps/docker/Dockerfile
+++ b/release/stable/opensuse423/test-deps/docker/Dockerfile
@@ -8,6 +8,9 @@ RUN zypper --non-interactive update --skip-interactive \
     && zypper --non-interactive install \
          sudo \
          tar \
+         curl \
+         wget \
+         hostname \
     # clean package manager cache
     && zypper clean -a \
     # remove package manager log file

--- a/release/stable/opensuse423/test-deps/docker/Dockerfile
+++ b/release/stable/opensuse423/test-deps/docker/Dockerfile
@@ -7,6 +7,7 @@ FROM ${BaseImage}
 RUN zypper --non-interactive update --skip-interactive \
     && zypper --non-interactive install \
          sudo \
+         tar \
     # clean package manager cache
     && zypper clean -a \
     # remove package manager log file

--- a/release/stable/ubuntu16.04/test-deps/docker/Dockerfile
+++ b/release/stable/ubuntu16.04/test-deps/docker/Dockerfile
@@ -7,6 +7,10 @@ FROM ${BaseImage}
 RUN apt-get update \
     && apt-get install -y \
         sudo \
+        curl \
+        wget \
+        iputils-ping \
+        iputils-tracepath \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/release/stable/ubuntu18.04/test-deps/docker/Dockerfile
+++ b/release/stable/ubuntu18.04/test-deps/docker/Dockerfile
@@ -7,6 +7,10 @@ FROM ${BaseImage}
 RUN apt-get update \
     && apt-get install -y \
         sudo \
+        curl \
+        wget \
+        iputils-ping \
+        iputils-tracepath \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/container.tests.ps1
+++ b/tests/container.tests.ps1
@@ -319,7 +319,7 @@ Describe "Linux Containers" -Tags 'Behavior', 'Linux' {
         BeforeAll{
             #apt-utils ca-certificates curl wget apt-transport-https locales gnupg2 inetutils-ping git sudo less procps
             $commands = @(
-                'locale-gen'
+                #'locale-gen'
                 'update-ca-certificates'
                 'openssl'
                 'less'
@@ -358,7 +358,7 @@ Describe "Linux Containers" -Tags 'Behavior', 'Linux' {
         BeforeAll{
             #apt-utils ca-certificates curl wget apt-transport-https locales gnupg2 inetutils-ping git sudo less procps
             $commands = @(
-                @{command = 'adduser'}
+                #@{command = 'adduser'}
                 @{command = 'bash'}
                 @{command = 'curl'}
                 @{command = 'find'}

--- a/tests/container.tests.ps1
+++ b/tests/container.tests.ps1
@@ -320,8 +320,7 @@ Describe "Linux Containers" -Tags 'Behavior', 'Linux' {
             #apt-utils ca-certificates curl wget apt-transport-https locales gnupg2 inetutils-ping git sudo less procps
             $commands = @(
                 #'locale-gen'
-                'update-ca-certificates'
-                'openssl'
+                # debian 'update-ca-certificates'
                 'less'
             )
 
@@ -369,6 +368,7 @@ Describe "Linux Containers" -Tags 'Behavior', 'Linux' {
                 @{command = 'sudo'}
                 @{command = 'tar'}
                 @{command = 'wget'}
+                @{command = 'openssl'}
             )
 
             $debianCommands = @(

--- a/tests/containerTestCommon.psm1
+++ b/tests/containerTestCommon.psm1
@@ -408,7 +408,7 @@ function Get-DockerCommandSource
     $runParams += '-nologo'
     $runParams += '-noprofile'
     $runParams += '-c'
-    $runParams += "(Get-Command -name '$Command' -CommandType '$CommandType').Source"
+    $runParams += "(Get-Command -name '$Command' -CommandType '$CommandType' -ErrorAction Ignore).Source"
 
     return Invoke-Docker -Command run -Params $runParams -SuppressHostOutput -PassThru
 }

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -145,6 +145,7 @@ jobs:
     vmImage: vs2017-win2016
     preview: false
     ciParameter: '-CI'
+    continueonerror: true
 
 # Use the TagFilter to filter to 1809 because the docker instance inside the agent only supports 1809
 - template: .vsts-ci/phase.yml


### PR DESCRIPTION
## PR Summary

`tar` is required to extract the test artifacts for release automation tests. OpenSUSE does not have tar in its base image.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
