### PR TITLE
Use the PowerShell Nanoserver image to build nanoserver

### DIFF
--- a/release/preview/nanoserver/docker/Dockerfile
+++ b/release/preview/nanoserver/docker/Dockerfile
@@ -1,20 +1,20 @@
 # escape=`
 # Args used by from statements must be defined here:
 ARG fromTag=1709
-ARG WindowsServerCoreVersion=latest
-ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
+ARG InstallerVersion=nanoserver
+ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
 
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away
-FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
+FROM ${InstallerRepo}:$InstallerVersion  AS installer-env
 
 # Arguments for installing PowerShell, must be defined in the container they are used
 ARG PS_VERSION=6.1.0-rc.1
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 

--- a/release/preview/nanoserver/docker/Dockerfile
+++ b/release/preview/nanoserver/docker/Dockerfile
@@ -32,8 +32,9 @@ RUN Write-host "Verifying valid Version..."; `
     } `
     Write-host "downloading: $url"; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri $url -outfile /powershell.zip -verbose; `
-    Expand-Archive powershell.zip -DestinationPath \PowerShell
+    New-Item -ItemType Directory /installer > $null ; `
+    Invoke-WebRequest -Uri $url -outfile /installer/powershell.zip -verbose; `
+    Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:${fromTag}

--- a/release/preview/nanoserver1809/docker/Dockerfile
+++ b/release/preview/nanoserver1809/docker/Dockerfile
@@ -1,20 +1,20 @@
 # escape=`
 # Args used by from statements must be defined here:
 ARG fromTag=1709
-ARG WindowsServerCoreVersion=latest
-ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
+ARG InstallerVersion=nanoserver
+ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
 
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away
-FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
+FROM ${InstallerRepo}:$InstallerVersion  AS installer-env
 
 # Arguments for installing PowerShell, must be defined in the container they are used
 ARG PS_VERSION=6.2.0-rc.1
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 

--- a/release/preview/nanoserver1809/docker/Dockerfile
+++ b/release/preview/nanoserver1809/docker/Dockerfile
@@ -32,8 +32,9 @@ RUN Write-host "Verifying valid Version..."; `
     } `
     Write-host "downloading: $url"; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri $url -outfile /powershell.zip -verbose; `
-    Expand-Archive powershell.zip -DestinationPath \PowerShell
+    New-Item -ItemType Directory /installer > $null ; `
+    Invoke-WebRequest -Uri $url -outfile /installer/powershell.zip -verbose; `
+    Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:${fromTag}

--- a/release/servicing/nanoserver/docker/Dockerfile
+++ b/release/servicing/nanoserver/docker/Dockerfile
@@ -1,20 +1,20 @@
 # escape=`
 # Args used by from statements must be defined here:
 ARG fromTag=1709
-ARG WindowsServerCoreVersion=latest
-ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
+ARG InstallerVersion=nanoserver
+ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
 
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away
-FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
+FROM ${InstallerRepo}:$InstallerVersion  AS installer-env
 
 # Arguments for installing PowerShell, must be defined in the container they are used
 ARG PS_VERSION=6.1.0
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 

--- a/release/servicing/nanoserver/docker/Dockerfile
+++ b/release/servicing/nanoserver/docker/Dockerfile
@@ -32,8 +32,9 @@ RUN Write-host "Verifying valid Version..."; `
     } `
     Write-host "downloading: $url"; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri $url -outfile /powershell.zip -verbose; `
-    Expand-Archive powershell.zip -DestinationPath \PowerShell
+    New-Item -ItemType Directory /installer > $null ; `
+    Invoke-WebRequest -Uri $url -outfile /installer/powershell.zip -verbose; `
+    Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:${fromTag}

--- a/release/servicing/nanoserver1809/docker/Dockerfile
+++ b/release/servicing/nanoserver1809/docker/Dockerfile
@@ -32,8 +32,9 @@ RUN Write-host "Verifying valid Version..."; `
     } `
     Write-host "downloading: $url"; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri $url -outfile /powershell.zip -verbose; `
-    Expand-Archive powershell.zip -DestinationPath \PowerShell
+    New-Item -ItemType Directory /installer > $null ; `
+    Invoke-WebRequest -Uri $url -outfile /installer/powershell.zip -verbose; `
+    Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:${fromTag}

--- a/release/servicing/nanoserver1809/docker/Dockerfile
+++ b/release/servicing/nanoserver1809/docker/Dockerfile
@@ -1,8 +1,8 @@
 # escape=`
 # Args used by from statements must be defined here:
 ARG fromTag=1709
-ARG WindowsServerCoreVersion=latest
-ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
+ARG InstallerVersion=nanoserver
+ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
 
 # Use server core as an installer container to extract PowerShell,
@@ -14,7 +14,7 @@ ARG PS_VERSION=6.1.0
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 

--- a/release/stable/nanoserver/docker/Dockerfile
+++ b/release/stable/nanoserver/docker/Dockerfile
@@ -1,20 +1,20 @@
 # escape=`
 # Args used by from statements must be defined here:
 ARG fromTag=1709
-ARG WindowsServerCoreVersion=latest
-ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
+ARG InstallerVersion=nanoserver
+ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
 
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away
-FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
+FROM ${InstallerRepo}:$InstallerVersion  AS installer-env
 
 # Arguments for installing PowerShell, must be defined in the container they are used
 ARG PS_VERSION=6.2.0
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 

--- a/release/stable/nanoserver/docker/Dockerfile
+++ b/release/stable/nanoserver/docker/Dockerfile
@@ -32,8 +32,9 @@ RUN Write-host "Verifying valid Version..."; `
     } `
     Write-host "downloading: $url"; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri $url -outfile /powershell.zip -verbose; `
-    Expand-Archive powershell.zip -DestinationPath \PowerShell
+    New-Item -ItemType Directory /installer > $null ; `
+    Invoke-WebRequest -Uri $url -outfile /installer/powershell.zip -verbose; `
+    Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:${fromTag}

--- a/release/stable/nanoserver1809/docker/Dockerfile
+++ b/release/stable/nanoserver1809/docker/Dockerfile
@@ -1,20 +1,20 @@
 # escape=`
 # Args used by from statements must be defined here:
 ARG fromTag=1709
-ARG WindowsServerCoreVersion=latest
-ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
+ARG InstallerVersion=nanoserver
+ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=mcr.microsoft.com/windows/nanoserver
 
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away
-FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
+FROM ${InstallerRepo}:$InstallerVersion  AS installer-env
 
 # Arguments for installing PowerShell, must be defined in the container they are used
 ARG PS_VERSION=6.2.0
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 

--- a/release/stable/nanoserver1809/docker/Dockerfile
+++ b/release/stable/nanoserver1809/docker/Dockerfile
@@ -32,8 +32,9 @@ RUN Write-host "Verifying valid Version..."; `
     } `
     Write-host "downloading: $url"; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri $url -outfile /powershell.zip -verbose; `
-    Expand-Archive powershell.zip -DestinationPath \PowerShell
+    New-Item -ItemType Directory /installer > $null ; `
+    Invoke-WebRequest -Uri $url -outfile /installer/powershell.zip -verbose; `
+    Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:${fromTag}

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -140,12 +140,12 @@ jobs:
 # Skipping previews on windows due to how long it takes to build on windows
 - template: .vsts-ci/phase.yml
   parameters:
-    name: nanoserver_ltsc_2016
-    imagename: nanoserver
-    vmImage: vs2017-win2016
+    name: nanoserver_1809
+    imagename: nanoserver1809
+    vmImage: windows-2019
     preview: false
     ciParameter: '-CI'
-    continueonerror: true
+    continueonerror: false
 
 # Use the TagFilter to filter to 1809 because the docker instance inside the agent only supports 1809
 - template: .vsts-ci/phase.yml


### PR DESCRIPTION
## PR Summary

Use the PowerShell Nano Server image to build nanoserver

## PR Context

ServerCore broke us by changing their tags.  Using nanoserver is faster and should be more reliable.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
