### PR TITLE
Add files to cause dependabot to open PRs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,36 @@
+version: 1
+
+# update_schedule: live is only supported on javascript, ruby:bundler, python, php:composer, dotnet:nuget, rust:cargo, elixir:hex
+
+update_configs:
+  - package_manager: "docker"
+    directory: "/release/preview/alpine/dependabot"
+    update_schedule: "daily"
+
+  - package_manager: "docker"
+    directory: "/release/preview/centos7/dependabot"
+    update_schedule: "daily"
+
+  - package_manager: "docker"
+    directory: "/release/preview/debian9/dependabot"
+    update_schedule: "daily"
+
+  - package_manager: "docker"
+    directory: "/release/preview/fedora28/dependabot"
+    update_schedule: "daily"
+
+  - package_manager: "docker"
+    directory: "/release/preview/nanoserver1809/dependabot"
+    update_schedule: "daily"
+
+  - package_manager: "docker"
+    directory: "/release/preview/opensuse423/dependabot"
+    update_schedule: "daily"
+
+  - package_manager: "docker"
+    directory: "/release/preview/ubuntu18.04/dependabot"
+    update_schedule: "daily"
+
+  - package_manager: "docker"
+    directory: "/release/preview/windowsservercore/dependabot"
+    update_schedule: "daily"

--- a/release/preview/alpine/dependabot/Dockerfile
+++ b/release/preview/alpine/dependabot/Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Dummy docker image to trigger dependabot PRs
+
+FROM alpine:3.8

--- a/release/preview/centos7/dependabot/Dockerfile
+++ b/release/preview/centos7/dependabot/Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Dummy docker image to trigger dependabot PRs
+
+FROM centos:7

--- a/release/preview/debian9/dependabot/Dockerfile
+++ b/release/preview/debian9/dependabot/Dockerfile
@@ -3,4 +3,4 @@
 
 # Dummy docker image to trigger dependabot PRs
 
-FROM debian:stretch
+FROM debian:9.9

--- a/release/preview/debian9/dependabot/Dockerfile
+++ b/release/preview/debian9/dependabot/Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Dummy docker image to trigger dependabot PRs
+
+FROM debian:stretch

--- a/release/preview/fedora28/dependabot/Dockerfile
+++ b/release/preview/fedora28/dependabot/Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Dummy docker image to trigger dependabot PRs
+
+FROM fedora:28

--- a/release/preview/nanoserver1809/dependabot/Dockerfile
+++ b/release/preview/nanoserver1809/dependabot/Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Dummy docker image to trigger dependabot PRs
+
+FROM mcr.microsoft.com/windows/nanoserver:1903

--- a/release/preview/opensuse423/dependabot/Dockerfile
+++ b/release/preview/opensuse423/dependabot/Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Dummy docker image to trigger dependabot PRs
+
+FROM opensuse/leap:42.3

--- a/release/preview/ubuntu18.04/dependabot/Dockerfile
+++ b/release/preview/ubuntu18.04/dependabot/Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Dummy docker image to trigger dependabot PRs
+
+FROM ubuntu:18.04

--- a/release/preview/windowsservercore/dependabot/Dockerfile
+++ b/release/preview/windowsservercore/dependabot/Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Dummy docker image to trigger dependabot PRs
+
+FROM mcr.microsoft.com/windows/servercore:1903


### PR DESCRIPTION
## PR Summary

Will cause dependabot to submit PRs when we need to update the images.  
We will have to actually update the image, but at least we will get a notice.
Addresses #240 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
