### PR TITLE
Fix BlackArch failing

### DIFF
--- a/release/community-stable/blackarch/docker/Dockerfile
+++ b/release/community-stable/blackarch/docker/Dockerfile
@@ -18,7 +18,7 @@ ARG BlackArch_Strap_URL=https://blackarch.org/strap.sh
 ADD ${BlackArch_Strap_URL} /tmp/strap.sh
 
 # Define Args for the needed to add the package
-ARG PS_VERSION=6.1.0
+ARG PS_VERSION=6.2.3
 ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-x64.tar.gz
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=6
@@ -92,9 +92,6 @@ RUN \
     # upgrade distro
     && pacman -Syyu --noconfirm \
     # clean downloaded packages
-    # create /var/cache/pacman/pkg directory to prevent pacman -Scc generating
-    # an error output about this missing directory
-    && mkdir /var/cache/pacman/pkg \
     && yes | pacman -Scc
 
 # Define args needed only for the labels

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -126,7 +126,7 @@ jobs:
     stable: false
     preview: false
     communityStable: true
-    continueonerror: true
+    continueonerror: false
 
 
 - template: .vsts-ci/phase.yml


### PR DESCRIPTION
## PR Summary

Fix #282 

- Update PowerShell version to 6.2.3

https://github.com/PowerShell/PowerShell-Docker/blob/1675dfe44a3df9bb4e71fd2464b9e86cf7ef9a90/release/community-stable/blackarch/docker/Dockerfile#L21

- Remove folder structure since updated container base image fixed the missing folder

https://github.com/PowerShell/PowerShell-Docker/blob/1675dfe44a3df9bb4e71fd2464b9e86cf7ef9a90/release/community-stable/blackarch/docker/Dockerfile#L95-L97

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [x] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
