### PR TITLE
Fix ParrotSec failing

### DIFF
--- a/release/community-stable/parrot/docker/Dockerfile
+++ b/release/community-stable/parrot/docker/Dockerfile
@@ -5,7 +5,7 @@
 # installed from Debian9 PowerShell package
 
 # Define arg(s) needed for the From statement
-ARG fromTag=4.4
+ARG fromTag=latest
 ARG imageRepo=parrotsec/parrot-core
 
 FROM ${imageRepo}:${fromTag} AS installer-env
@@ -14,7 +14,7 @@ FROM ${imageRepo}:${fromTag} AS installer-env
 ENTRYPOINT [ ]
 
 # Define Args for the needed to add the package
-ARG PS_VERSION=6.1.0
+ARG PS_VERSION=6.2.3
 ARG PS_PACKAGE=powershell_${PS_VERSION}-1.debian.9_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=6
@@ -23,10 +23,10 @@ ARG PS_INSTALL_VERSION=6
 ADD ${PS_PACKAGE_URL} /tmp/powershell.deb
 
 # Define Args for the needed to add the package
-ARG DEBIAN_PACKAGE_URL=http://ftp.us.debian.org/debian/pool/main/i/icu/libicu57_57.1-6+deb9u2_amd64.deb
+ARG DEBIAN_PACKAGE_URL=http://ftp.us.debian.org/debian/pool/main/i/icu/libicu57_57.1-6+deb9u3_amd64.deb
 
 # Download the libicu57 Debian package and save it
-ADD ${DEBIAN_PACKAGE_URL} /tmp/libicu57_57.1-6+deb9u2_amd64.deb
+ADD ${DEBIAN_PACKAGE_URL} /tmp/libicu57_57.1-6+deb9u3_amd64.deb
 
 # Define Args and Env needed to create links
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
@@ -63,9 +63,9 @@ RUN \
     # generate locale
     && locale-gen && update-locale \
     # install required libicu57 package
-    && dpkg -i /tmp/libicu57_57.1-6+deb9u2_amd64.deb \
+    && dpkg -i /tmp/libicu57_57.1-6+deb9u3_amd64.deb \
     # remove libicu57 package
-    && rm -f /tmp/libicu57_57.1-6+deb9u2_amd64.deb \
+    && rm -f /tmp/libicu57_57.1-6+deb9u3_amd64.deb \
     # install powershell package
     && apt-get install -y /tmp/powershell.deb \
     # remove powershell package

--- a/release/community-stable/parrot/getLatestTag.ps1
+++ b/release/community-stable/parrot/getLatestTag.ps1
@@ -4,7 +4,7 @@
 # return objects representing the tags we need to base the parrot image on
 
 # The versions of parrot we care about
-$shortTags = @('4.4')
+$shortTags = @('latest')
 
 $parent = Join-Path -Path $PSScriptRoot -ChildPath '..'
 $repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath '..'

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -135,7 +135,7 @@ jobs:
     stable: false
     preview: false
     communityStable: true
-    continueonerror: true
+    continueonerror: false
 
 - template: .vsts-ci/phase.yml
   parameters:
@@ -144,6 +144,7 @@ jobs:
     stable: false
     preview: false
     communityStable: true
+    continueonerror: false
 
 - template: .vsts-ci/phase.yml
   parameters:
@@ -152,6 +153,7 @@ jobs:
     stable: false
     preview: false
     communityStable: true
+    continueonerror: false
 
 - template: .vsts-ci/phase.yml
   parameters:
@@ -169,6 +171,7 @@ jobs:
     stable: false
     preview: false
     communityStable: true
+    continueonerror: false
 
 
 # The -CI filters to LTSC-2016 for nanoserver by default, which is the only thing that works on Hosted VS2017


### PR DESCRIPTION
## PR Summary

fix #289 

- Update Base Container image from 4.4 to latest tag
- Update PowerShell version from 6.1.0 to 6.2.3
- Update libicu57_57.1 package source url and filename


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [x] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
