### PR TITLE
MCR is the defacto source for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The Dockerfiles in the community folder were contributed by the community and ar
 To run PowerShell from using a container:
 
 ```sh
-$ docker run -it microsoft/powershell
-Unable to find image 'microsoft/powershell:latest' locally
-latest: Pulling from microsoft/powershell
+$ docker run -it mcr.microsoft.com/powershell
+Unable to find image 'mcr.microsoft.com/powershell:latest' locally
+latest: Pulling from mcr.microsoft.com/powershell
 cad964aed91d: Already exists
 3a80a22fea63: Already exists
 50de990d7957: Already exists
@@ -44,7 +44,7 @@ adf6ad28fa0e: Pull complete
 10db13a8ca02: Pull complete
 75bdb54ff5ae: Pull complete
 Digest: sha256:92c79c5fcdaf3027626643aef556344b8b4cbdaccf8443f543303319949c7f3a
-Status: Downloaded newer image for microsoft/powershell:latest
+Status: Downloaded newer image for mcr.microsoft.com/powershell:latest
 PowerShell
 Copyright (c) Microsoft Corporation. All rights reserved.
 

--- a/assets/README.powershell.md
+++ b/assets/README.powershell.md
@@ -27,11 +27,11 @@ If you are new to PowerShell and want to learn more, see the [getting started][]
 
 ## How to Use This Image
 
-See our [Docker examples](https://github.com/PowerShell/PowerShell/tree/master/docker#examples).
+See our [Docker examples](https://github.com/PowerShell/PowerShell-Docker#examples).
 
 ## Configuration
 
-See our [Docker examples](https://github.com/PowerShell/PowerShell/tree/master/docker#examples).
+See our [Docker examples](https://github.com/PowerShell/PowerShell-Docker#examples).
 
 ## Full Tag Listing
 


### PR DESCRIPTION
## PR Summary

As seen on the docker hub Powershell page and as per [other blog posts](https://techcommunity.microsoft.com/t5/Containers/Windows-Server-2019-Now-Available/ba-p/382430), MCR is the defect registry for images. Otherwise this doesn't align with all the other doco, including the docker hub page which links here.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
