### PR TITLE
Test deps image should now use Fedora 30

### DIFF
--- a/release/preview/fedora/test-deps/docker/Dockerfile
+++ b/release/preview/fedora/test-deps/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG BaseImage=mcr.microsoft.com/powershell:fedora-28
 
 FROM ${BaseImage}
 
-ARG fromTag=28
+ARG fromTag=30
 
 # Install dependencies and clean up
 RUN dnf install -y \
@@ -19,8 +19,8 @@ ENV POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-Fedora-${fromTag}
 
 # Define args needed only for the labels
 ARG VCS_REF="none"
-ARG IMAGE_NAME=mcr.microsoft.com/powershell/test-deps:fedora-28
-ARG PS_VERSION=6.2.0
+ARG IMAGE_NAME=mcr.microsoft.com/powershell/test-deps:fedora-30
+ARG PS_VERSION=6.2.3
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \
       readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md" \


### PR DESCRIPTION
## PR Summary

Should fix #257

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
