### PR TITLE
Fix fedora security updating

### DIFF
--- a/release/preview/fedora/docker/Dockerfile
+++ b/release/preview/fedora/docker/Dockerfile
@@ -22,21 +22,40 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 # Install dependencies and clean up
 RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     && dnf install -y /tmp/powershell.rpm \
-    && dnf install -y \
-    # less is needed for help
-    less \
-    # Needed to run localdef
-        glibc-locale-source \
-    # Invoke-WebRequest doesn't work correctly without this
-    compat-openssl10 \
-    ca-certificates \
-    gssntlmssp \
-    && dnf upgrade-minimal -y --security \
-    && dnf clean all \
-    && localedef --charmap=UTF-8 --inputfile=en_US $LANG \
     # remove powershell package
     && rm /tmp/powershell.rpm \
+    && dnf install -y \
+    # less is needed for help
+      less \
+    # Needed to run localdef
+      glibc-locale-source \
+    # Invoke-WebRequest doesn't work correctly without this
+      compat-openssl10 \
+      ca-certificates \
+      gssntlmssp \
     && ln -sf /opt/microsoft/powershell/7-preview/pwsh /usr/bin/pwsh \
+    # For whatever reason FEDORA-2019-27e7b92407 has to be patched manually
+    && dnf upgrade -y libmodulemd1 \
+    # This installs most security advisories
+    && dnf upgrade-minimal -y --security \
+    # query and install any remaining security advisories
+    && pwsh \
+        -NoLogo \
+        -NoProfile \
+        -Command " \
+          (dnf updateinfo list -q --security) |  \
+              Foreach-Object { \
+                  \$advisory=(\$_ -split ' ')[0]; \
+                  Write-Host '******* Patching *********'; \
+                  Write-Host \$advisory; \
+                  Write-Host '************************'; \
+                  dnf upgrade -y --advisory=\$advisory \
+              }" \
+    && echo "verifying all security advisories are installed..." \
+    && dnf updateinfo list -q --security \
+    && echo "end - verifying all security advisories are installed..." \
+    && dnf clean all \
+    && localedef --charmap=UTF-8 --inputfile=en_US $LANG \
     # intialize powershell module cache
     && pwsh \
         -NoLogo \

--- a/release/preview/fedora/docker/Dockerfile
+++ b/release/preview/fedora/docker/Dockerfile
@@ -35,7 +35,15 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
       gssntlmssp \
     && ln -sf /opt/microsoft/powershell/7-preview/pwsh /usr/bin/pwsh \
     # For whatever reason FEDORA-2019-27e7b92407 has to be patched manually
-    && dnf upgrade -y libmodulemd1 \
+    # to do this, upgrade libmodulemd1, if it is installed
+    && pwsh \
+        -NoLogo \
+        -NoProfile \
+        -Command " \
+          \$module = (dnf list installed libmodulemd1 | Select-String -SimpleMatch libmodulemd1);  \
+          if(\$module) { \
+             dnf upgrade -y libmodulemd1 \
+          }" \
     # This installs most security advisories
     && dnf upgrade-minimal -y --security \
     # query and install any remaining security advisories


### PR DESCRIPTION
## PR Summary

Fix fedora security updating

- FEDORA-2019-27e7b92407 had to be completely manually installed
- FEDORA-2019-3377813d18 had to be installed by advisory name

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
