### PR TITLE
Convert release build to use generated matrix

### DIFF
--- a/.vsts-ci/phase.yml
+++ b/.vsts-ci/phase.yml
@@ -45,7 +45,7 @@ jobs:
     condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
   - pwsh: |
-      ./build.ps1 -build -name '$(ImageName)' -IncludeKnownIssues -Channel '$(Channel)' -TestLogPostfix '$(ImageName)-stable' ${{ parameters.ciParameter }} -Repository stable/powershell
+      ./build.ps1 -build -name '$(ImageName)' -IncludeKnownIssues -Channel '$(Channel)' -TestLogPostfix '$(ImageName)-$(Channel)' ${{ parameters.ciParameter }} -Repository $(Channel)/powershell
     displayName: $(ImageName) $(Channel)
     condition: and( succeededOrFailed(), ne(variables['Channel'],''))
     continueOnError: ${{ parameters.continueonerror }}

--- a/.vsts-ci/releasePhase.yml
+++ b/.vsts-ci/releasePhase.yml
@@ -1,19 +1,26 @@
 parameters:
-  pool: 'Hosted Ubuntu 1604'
-  channel: 'stable'
+  vmImage: 'ubuntu-16.04'
   jobName: 'none'
   releaseTag: ''
   ACR: 'no'
+  maxParallel: 5
+  dependsOn: []
 
 jobs:
 - job: ${{ parameters.jobName }}
+  dependsOn:
+    ${{ parameters.dependsOn }}
+  strategy:
+      matrix: $[ ${{ parameters.matrix }} ]
+      maxParallel: ${{ parameters.maxParallel }}
   variables:
     dockerImage: 'powershell'
     Channel: ${{ parameters.channel }}
     ACR: ${{ parameters.ACR }}
     releaseTag: ${{ parameters.releaseTag }}
 
-  pool: ${{ parameters.pool }}
+  pool:
+    vmImage: ${{ parameters.vmImage }}
   timeoutInMinutes: 135
 
   displayName: ${{ parameters.jobName }}
@@ -22,35 +29,56 @@ jobs:
   - pwsh: |
       Write-Host "##vso[task.setvariable variable=ACR_NAME;]$env:ACR_NAME_VAR"
     displayName: 'Enable ACR'
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
-  - pwsh: |
-      $version = '$(releaseTag)' -replace '^v', ''
-      Write-Host "##vso[task.setvariable variable=Version;]$version"
-    displayName: 'Set Version'
-
-  - pwsh: |
-      $namespace = '$(releaseTag)'.ToLowerInvariant()
+  - powershell: |
+      switch('$(Channel)') {
+        'stable' {
+          $releaseTag = '$(stableReleaseTag)'
+          $version = '$(stableReleaseTag)' -replace '^v', ''
+        }
+        'preview' {
+          $releaseTag = '$(previewReleaseTag)'
+          $version = '$(previewReleaseTag)' -replace '^v', ''
+        }
+        default {
+          throw "Unknown channel '$(Channel)'"
+        }
+      }
+      $namespace = $releaseTag.ToLowerInvariant()
       Write-Host "##vso[task.setvariable variable=dockerNamespace;]$namespace"
-    displayName: 'Set dockerNamespace'
+      $version = $releaseTag -replace '^v', ''
+      $command = "vso[task.setvariable variable=version]$version"
+      Write-Host $command
+      Write-Host "##$command"
+    displayName: 'Set Version'
+    name: get
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
-  - pwsh: 'Get-ChildItem env:'
+  - pwsh: |
+      Get-ChildItem env: | Out-String -Width 1000
     displayName: 'Capture Environment'
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
   - pwsh: 'docker login $(dockerHost) -u $(dockerUserName) -p $(dockerKey)'
     displayName: 'docker login'
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
   - pwsh: ' az login --service-principal -u $(az_url) -p $(az_key) --tenant $(az_name)'
     displayName: 'az login'
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
   - pwsh: |
       az account set --subscription $(StorageSubscriptionName)
-      $querystring = az storage account generate-sas --account-name $(StorageAccount) --services b --resource-types o --expiry ((get-date).AddDays(2).ToString("yyyy-MM-dd")) --permission r --https-only | convertfrom-json
+      $querystring = az storage account generate-sas --account-name $(StorageAccount) --services b --resource-types o --expiry ((get-date).AddDays(1).ToString("yyyy-MM-dd")) --permission r --https-only | convertfrom-json
       $url = "https://$(StorageAccount).blob.core.windows.net/?$querystring"
       Write-Host "##vso[task.setvariable variable=SasUrl;]$url"
     displayName: 'Set SasUrl variable'
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
   - pwsh: 'Install-module pester -Scope CurrentUser -Force -SkipPublisherCheck'
     displayName: 'Install Pester'
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
   - pwsh: |
       az account set --subscription $(AcrSubscriptionName)
@@ -72,25 +100,21 @@ jobs:
         $extraParams.Add('SasUrl',$env:SASURL)
       }
 
-      if($env:$(Channel) -eq 'true')
-      {
-        ./build.ps1 -Build -ImageName $(dockerHost) -All -Channel $(channel) @extraParams -version '$(Version)' -Repository $(dockerNamespace)/$(dockerImage)
-      }
-      else
-      {
-        Write-Host 'Current channel disabled, skipping ...'
-      }
+      ./build.ps1 -Build -ImageName $(dockerHost) -name '$(ImageName)' -Channel $(channel) -TestLogPostfix '$(ImageName)-$(Channel)' @extraParams -version '$(Version)' -Repository $(dockerNamespace)/$(dockerImage)
     displayName: 'Build All $(Channel)'
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
   - pwsh: 'docker logout $(dockerHost)'
     displayName: 'docker logout'
-    condition: always()
+    condition: and( always(), ne(variables['Channel'],''))
 
   - pwsh: 'az logout'
     displayName: 'az logout'
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
+    condition: and( succeededOrFailed(), ne(variables['Channel'],''))
     inputs:
       sourceScanPath: '$(Build.SourcesDirectory)'
       snapshotForceEnabled: true

--- a/.vsts-ci/releaseStage.yml
+++ b/.vsts-ci/releaseStage.yml
@@ -38,3 +38,6 @@ stages:
         jobName: Build_Win
         vmImage: windows-2019
         ACR: yes
+        # failure rate is High in ACR for Windows and we have few images.
+        # No reason to stress the system.
+        maxParallel: 1

--- a/.vsts-ci/releaseStage.yml
+++ b/.vsts-ci/releaseStage.yml
@@ -1,0 +1,40 @@
+parameters:
+  channel: 'preview'
+  vmImage: 'ubuntu-16.04'
+  acr: 'All'
+  useacr: 'false'
+  osFilter: 'All'
+
+stages:
+  - stage: GenerateYaml_${{ parameters.channel }}
+    dependsOn: []
+    displayName: Build ${{ parameters.channel }}
+    jobs:
+    - job: GenerateYaml_${{ parameters.channel }}
+      pool:
+        vmImage: ubuntu-16.04
+      displayName: Generate Matrix YAML ${{ parameters.channel }}
+      steps:
+      - pwsh: |
+          ./build.ps1 -GenerateMatrixJson -Channel ${{ parameters.channel }} -Verbose -Acr ${{ parameters.acr }} -OsFilter  ${{ parameters.osFilter }}
+        displayName: Generate Matrix YAML
+        condition: succeededOrFailed()
+        name: matrix
+      - pwsh: |
+          dir env:matrix_* | out-string -Width 1000
+        displayName: Capture Matrix YAML
+        condition: succeededOrFailed()
+    - template: releasePhase.yml
+      parameters:
+        matrix: dependencies.GenerateYaml_${{ parameters.channel }}.outputs['matrix.matrix_${{ parameters.channel }}_linux']
+        dependsOn:
+          - GenerateYaml_${{ parameters.channel }}
+        jobName: Build_Linux
+    - template: releasePhase.yml
+      parameters:
+        matrix: dependencies.GenerateYaml_${{ parameters.channel }}.outputs['matrix.matrix_${{ parameters.channel }}_windows']
+        dependsOn:
+          - GenerateYaml_${{ parameters.channel }}
+        jobName: Build_Win
+        vmImage: windows-2019
+        ACR: yes

--- a/.vsts-ci/releasebuild.yml
+++ b/.vsts-ci/releasebuild.yml
@@ -7,117 +7,91 @@ resources:
 variables:
   POWERSHELL_TELEMETRY_OPTOUT: 1
 
-jobs:
-- template: releasePhase.yml
-  parameters:
-    channel: STABLE
-    jobName: stableLinux
-    releaseTag: $(stableReleaseTag)
-    pool: Hosted Ubuntu 1604
-    ACR: no
+stages:
+  - template: releaseStage.yml
+    parameters:
+      channel: stable
+  - template: releaseStage.yml
+    parameters:
+      channel: preview
 
-- template: releasePhase.yml
-  parameters:
-    channel: PREVIEW
-    jobName: previewLinux
-    releaseTag: $(previewReleaseTag)
-    pool: Hosted Ubuntu 1604
-    ACR: no
+  - stage: GenerateManifests
+    dependsOn:
+      - GenerateYaml_stable
+      - GenerateYaml_preview
+    jobs:
+    - job: PreviewManifestPhase
+      variables:
+        releaseTag: $(previewReleaseTag)
+        channel: PREVIEW
 
-- template: releasePhase.yml
-  parameters:
-    channel: STABLE
-    jobName: stableWindows
-    releaseTag: $(stableReleaseTag)
-    pool: Hosted VS2017
-    ACR: yes
+      displayName: Create Preview Manifest Lists
+      condition: succeededOrFailed()
+      pool:
+        name: PowerShell
+        timeoutInMinutes: 30
 
-- template: releasePhase.yml
-  parameters:
-    channel: PREVIEW
-    jobName: previewWindows
-    releaseTag: $(previewReleaseTag)
-    pool: Hosted VS2017
-    ACR: yes
+      steps:
+      - template: manifestSteps.yml
+    - job: StableManifestPhase
+      variables:
+        releaseTag: $(stableReleaseTag)
+        channel: STABLE
 
-- job: PreviewManifestPhase
-  variables:
-    releaseTag: $(previewReleaseTag)
-    channel: PREVIEW
+      displayName: Create Stable Manifest Lists
 
-  displayName: Create Preview Manifest Lists
+      condition: succeededOrFailed()
+      pool:
+        name: PowerShell
+        timeoutInMinutes: 30
 
-  dependsOn:
-   - previewLinux
-   - previewWindows
-  condition: succeededOrFailed()
-  pool:
-    name: PowerShell
-    timeoutInMinutes: 30
+      steps:
+      - template: manifestSteps.yml
+  - stage: GenerateTagsYaml
+    dependsOn: []
+    jobs:
+    - job: GenerateTagsYaml
 
-  steps:
-  - template: manifestSteps.yml
+      displayName: Generate Tags YAML
 
-- job: StableManifestPhase
-  variables:
-    releaseTag: $(stableReleaseTag)
-    channel: STABLE
+      condition: succeededOrFailed()
+      pool:
+        name: Hosted Ubuntu 1604
+        timeoutInMinutes: 30
 
-  displayName: Create Stable Manifest Lists
+      steps:
+      - powershell: |
+          $stableVersion = '$(stableReleaseTag)' -replace '^v', ''
+          Write-Host "##vso[task.setvariable variable=StableVersion;]$stableVersion"
+          $previewVersion = '$(previewReleaseTag)' -replace '^v', ''
+          Write-Host "##vso[task.setvariable variable=PreviewVersion;]$previewVersion"
+        displayName: 'Set Versions'
 
-  dependsOn:
-   - stableWindows
-   - stableLinux
-  condition: succeededOrFailed()
-  pool:
-    name: PowerShell
-    timeoutInMinutes: 30
+      - powershell: 'Get-ChildItem env:'
+        displayName: 'Capture Environment'
 
-  steps:
-  - template: manifestSteps.yml
+      - powershell: 'Install-module pester -Scope CurrentUser -Force -SkipPublisherCheck'
+        displayName: 'Install Pester'
 
-- job: GenerateTagsYaml
+      - powershell: |
+            $yaml = ./build.ps1 -GenerateTagsYaml -Channel stable, preview -StableVersion $(StableVersion) -PreviewVersion $(PreviewVersion)
+            $yaml | Out-File -Encoding ascii -Path ./tagsmetadata.yaml
+            Get-ChildItem -Path ./tagsmetadata.yaml | Select-Object -ExpandProperty FullName | ForEach-Object {
+                    Write-Host "##vso[artifact.upload containerfolder=artifacts;artifactname=artifacts]$_"
+                }
+        displayName: Generate Tags YAML
 
-  displayName: Generate Tags YAML
+      - powershell: |
+          $path = '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/releaseTags.json'
+          @{
+            'previewReleaseTag' = '$(previewReleaseTag)'
+            'stableReleaseTag' = '$(stableReleaseTag)'
+          }|convertto-json | out-file -FilePath $path -Encoding ascii
+          Write-Host "##vso[artifact.upload containerfolder=releaseTags;artifactname=releaseTags]$path"
+        displayName: Save release Tags
 
-  condition: succeededOrFailed()
-  pool:
-    name: Hosted Ubuntu 1604
-    timeoutInMinutes: 30
-
-  steps:
-  - powershell: |
-      $stableVersion = '$(stableReleaseTag)' -replace '^v', ''
-      Write-Host "##vso[task.setvariable variable=StableVersion;]$stableVersion"
-      $previewVersion = '$(previewReleaseTag)' -replace '^v', ''
-      Write-Host "##vso[task.setvariable variable=PreviewVersion;]$previewVersion"
-    displayName: 'Set Versions'
-
-  - powershell: 'Get-ChildItem env:'
-    displayName: 'Capture Environment'
-
-  - powershell: 'Install-module pester -Scope CurrentUser -Force -SkipPublisherCheck'
-    displayName: 'Install Pester'
-
-  - powershell: |
-        $yaml = ./build.ps1 -GenerateTagsYaml -Channel stable, preview -StableVersion $(StableVersion) -PreviewVersion $(PreviewVersion)
-        $yaml | Out-File -Encoding ascii -Path ./tagsmetadata.yaml
-        Get-ChildItem -Path ./tagsmetadata.yaml | Select-Object -ExpandProperty FullName | ForEach-Object {
-                Write-Host "##vso[artifact.upload containerfolder=artifacts;artifactname=artifacts]$_"
-            }
-    displayName: Generate Tags YAML
-
-  - powershell: |
-      $path = '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/releaseTags.json'
-      @{
-        'previewReleaseTag' = '$(previewReleaseTag)'
-        'stableReleaseTag' = '$(stableReleaseTag)'
-      }|convertto-json | out-file -FilePath $path -Encoding ascii
-      Write-Host "##vso[artifact.upload containerfolder=releaseTags;artifactname=releaseTags]$path"
-    displayName: Save release Tags
-
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
-    inputs:
-      sourceScanPath: '$(Build.SourcesDirectory)'
-      snapshotForceEnabled: true
+      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+        displayName: 'Component Detection'
+        inputs:
+          sourceScanPath: '$(Build.SourcesDirectory)'
+          snapshotForceEnabled: true


### PR DESCRIPTION
## PR Summary

Convert release build to use generated matrix
This will make it easier to add LTS
This also has the benefit that each image is not individually retry-able. 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
