### PR TITLE
Ensure coverage of all active Windows releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,5 +14,5 @@
 - **Adds a new image or tag**
   - [ ] Not Applicable
 - **OR**
-  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
+  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
   - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)

--- a/release/lts/nanoserver1809/dependabot/Dockerfile
+++ b/release/lts/nanoserver1809/dependabot/Dockerfile
@@ -3,4 +3,4 @@
 
 # Dummy docker image to trigger dependabot PRs
 
-FROM mcr.microsoft.com/windows/nanoserver:1903
+FROM mcr.microsoft.com/windows/nanoserver:2004

--- a/release/lts/nanoserver1809/meta.json
+++ b/release/lts/nanoserver1809/meta.json
@@ -1,10 +1,20 @@
 {
-    "IsLinux" : false,
+    "IsLinux": false,
     "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
     "osVersion": "Nano Server, version ${fromTag}",
     "shortTags": [
-        {"Tag": "1809"},
-        {"Tag": "1903"}
+        {
+            "Tag": "1809"
+        },
+        {
+            "Tag": "1903"
+        },
+        {
+            "Tag": "1909"
+        },
+        {
+            "Tag": "2004"
+        }
     ],
     "tagTemplates": [
         "lts-nanoserver-#shorttag#"

--- a/release/lts/windowsservercore/dependabot/Dockerfile
+++ b/release/lts/windowsservercore/dependabot/Dockerfile
@@ -3,4 +3,4 @@
 
 # Dummy docker image to trigger dependabot PRs
 
-FROM mcr.microsoft.com/windows/servercore:1903
+FROM mcr.microsoft.com/windows/servercore:2004

--- a/release/lts/windowsservercore/getLatestTag.ps1
+++ b/release/lts/windowsservercore/getLatestTag.ps1
@@ -14,6 +14,6 @@ $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath -Force
 
 # The versions of nanoserver we care about
-$shortTags = @('1809','1903')
+$shortTags = @('1809', '1903', '1909', '2004')
 
 Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/servercore" -FullTagFilter '\d{4}[-_]KB\d{7}' -Mcr

--- a/release/preview/nanoserver1809/dependabot/Dockerfile
+++ b/release/preview/nanoserver1809/dependabot/Dockerfile
@@ -3,4 +3,4 @@
 
 # Dummy docker image to trigger dependabot PRs
 
-FROM mcr.microsoft.com/windows/nanoserver:1903
+FROM mcr.microsoft.com/windows/nanoserver:2004

--- a/release/preview/nanoserver1809/meta.json
+++ b/release/preview/nanoserver1809/meta.json
@@ -1,11 +1,20 @@
 {
-    "IsLinux" : false,
+    "IsLinux": false,
     "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
     "osVersion": "Nano Server, version ${fromTag}",
     "shortTags": [
-        {"Tag": "1809"},
-        {"Tag": "1903"},
-        {"Tag": "1909"}
+        {
+            "Tag": "1809"
+        },
+        {
+            "Tag": "1903"
+        },
+        {
+            "Tag": "1909"
+        },
+        {
+            "Tag": "2004"
+        }
     ],
     "tagTemplates": [
         "#psversion#-nanoserver-#tag#",

--- a/release/preview/windowsservercore/dependabot/Dockerfile
+++ b/release/preview/windowsservercore/dependabot/Dockerfile
@@ -3,4 +3,4 @@
 
 # Dummy docker image to trigger dependabot PRs
 
-FROM mcr.microsoft.com/windows/servercore:1903
+FROM mcr.microsoft.com/windows/servercore:2004

--- a/release/preview/windowsservercore/getLatestTag.ps1
+++ b/release/preview/windowsservercore/getLatestTag.ps1
@@ -14,6 +14,6 @@ $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath -Force
 
 # The versions of nanoserver we care about
-$shortTags = @('1809','1903','1909')
+$shortTags = @('1809', '1903', '1909', '2004')
 
 Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/servercore" -FullTagFilter '\d{4}[-_]KB\d{7}' -Mcr

--- a/release/preview/windowsservercore/getLatestTag.ps1
+++ b/release/preview/windowsservercore/getLatestTag.ps1
@@ -3,17 +3,18 @@
 
 # return objects representing the tags we need to base the nanoserver image on
 
+
 param(
     [Switch]
-    $CI
+    $CI,
+    # The versions of nanoserver we care about
+    [string[]]
+    $ShortTags
 )
 
 $parent = Join-Path -Path $PSScriptRoot -ChildPath '..'
 $repoRoot = Join-Path -path (Join-Path -Path $parent -ChildPath '..') -ChildPath '..'
 $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
-Import-Module $modulePath -Force
-
-# The versions of nanoserver we care about
-$shortTags = @('1809', '1903', '1909', '2004')
+Import-Module $modulePath
 
 Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/servercore" -FullTagFilter '\d{4}[-_]KB\d{7}' -Mcr

--- a/release/preview/windowsservercore/meta.json
+++ b/release/preview/windowsservercore/meta.json
@@ -2,11 +2,25 @@
     "IsLinux": false,
     "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
     "osVersion": "Windows Server Core, version ${fromTag}",
+    "shortTags": [
+        {
+            "Tag": "1809"
+        },
+        {
+            "Tag": "1903"
+        },
+        {
+            "Tag": "1909"
+        },
+        {
+            "Tag": "2004"
+        }
+    ],
     "Base64EncodePackageUrl": true,
     "tagTemplates": [
         "#psversion#-windowsservercore-#tag#",
         "preview-windowsservercore-#shorttag#"
-    ]    ,
+    ],
     "TestProperties": {
         "size": 1
     }

--- a/release/servicing/nanoserver1809/meta.json
+++ b/release/servicing/nanoserver1809/meta.json
@@ -1,11 +1,20 @@
 {
-    "IsLinux" : false,
+    "IsLinux": false,
     "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
     "osVersion": "Nano Server, version ${fromTag}",
     "shortTags": [
-        {"Tag": "1809"},
-        {"Tag": "1903"},
-        {"Tag": "1909"}
+        {
+            "Tag": "1809"
+        },
+        {
+            "Tag": "1903"
+        },
+        {
+            "Tag": "1909"
+        },
+        {
+            "Tag": "2004"
+        }
     ],
     "tagTemplates": [
         "#psversion#-nanoserver-#tag#"

--- a/release/servicing/windowsservercore/getLatestTag.ps1
+++ b/release/servicing/windowsservercore/getLatestTag.ps1
@@ -14,6 +14,6 @@ $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath -Force
 
 # The versions of nanoserver we care about
-$shortTags = @('1809','1903','1909')
+$shortTags = @('1809', '1903', '1909', '2004')
 
 Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/servercore" -FullTagFilter '\d{4}[-_]KB\d{7}' -Mcr

--- a/release/stable/nanoserver1809/meta.json
+++ b/release/stable/nanoserver1809/meta.json
@@ -1,11 +1,20 @@
 {
-    "IsLinux" : false,
+    "IsLinux": false,
     "PackageFormat": "PowerShell-${PS_VERSION}-win-x64.zip",
     "osVersion": "Nano Server, version ${fromTag}",
     "shortTags": [
-        {"Tag": "1809"},
-        {"Tag": "1903"},
-        {"Tag": "1909"}
+        {
+            "Tag": "1809"
+        },
+        {
+            "Tag": "1903"
+        },
+        {
+            "Tag": "1909"
+        },
+        {
+            "Tag": "2004"
+        }
     ],
     "tagTemplates": [
         "#psversion#-nanoserver-#tag#",

--- a/release/stable/windowsservercore/getLatestTag.ps1
+++ b/release/stable/windowsservercore/getLatestTag.ps1
@@ -14,6 +14,6 @@ $modulePath = Join-Path -Path $repoRoot -ChildPath 'tools\getDockerTags'
 Import-Module $modulePath -Force
 
 # The versions of nanoserver we care about
-$shortTags = @('1809','1903','1909')
+$shortTags = @('1809', '1903', '1909', '2004')
 
 Get-DockerTags -ShortTags $shortTags -Image "mcr.microsoft.com/windows/servercore" -FullTagFilter '\d{4}[-_]KB\d{7}' -Mcr


### PR DESCRIPTION
## PR Summary

This adds Windows 2004 releases to all the lists, and Windows 1909 to a
few lists from which it was missing.

This should replace #436, the Dependabot reminder that Windows 2004 is now available.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
    - Nothing in this for Windows versions
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
    - Nothing apparent that needs updating.
