### PR TITLE
Be sure to disable telemetry when running pwsh when preparing the docker image

### DIFF
--- a/release/community-stable/amazonlinux/docker/Dockerfile
+++ b/release/community-stable/amazonlinux/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/community-stable/archlinux/docker/Dockerfile
+++ b/release/community-stable/archlinux/docker/Dockerfile
@@ -101,6 +101,7 @@ RUN \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/community-stable/blackarch/docker/Dockerfile
+++ b/release/community-stable/blackarch/docker/Dockerfile
@@ -116,6 +116,7 @@ RUN \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/community-stable/clearlinux/docker/Dockerfile
+++ b/release/community-stable/clearlinux/docker/Dockerfile
@@ -47,6 +47,7 @@ RUN \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/community-stable/kalilinux/docker/Dockerfile
+++ b/release/community-stable/kalilinux/docker/Dockerfile
@@ -63,6 +63,7 @@ RUN \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/community-stable/parrotsec/docker/Dockerfile
+++ b/release/community-stable/parrotsec/docker/Dockerfile
@@ -68,6 +68,7 @@ RUN \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/community-stable/photon/docker/Dockerfile
+++ b/release/community-stable/photon/docker/Dockerfile
@@ -85,6 +85,7 @@ RUN \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/alpine39/docker/Dockerfile
+++ b/release/lts/alpine39/docker/Dockerfile
@@ -83,6 +83,7 @@ RUN apk add --no-cache \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/centos7/docker/Dockerfile
+++ b/release/lts/centos7/docker/Dockerfile
@@ -44,6 +44,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/centos8/docker/Dockerfile
+++ b/release/lts/centos8/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/debian10/docker/Dockerfile
+++ b/release/lts/debian10/docker/Dockerfile
@@ -82,6 +82,7 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/debian11/docker/Dockerfile
+++ b/release/lts/debian11/docker/Dockerfile
@@ -82,6 +82,7 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/debian9/docker/Dockerfile
+++ b/release/lts/debian9/docker/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/fedora/docker/Dockerfile
+++ b/release/lts/fedora/docker/Dockerfile
@@ -44,6 +44,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           try { \$packageList = dnf list installed libmodulemd1} \
           catch {}; \
           \$module = (\$packageList | Select-String -SimpleMatch libmodulemd1);  \
@@ -61,6 +62,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           Write-Host '******* Getting security advisory list *********'; \
           (dnf updateinfo list -q --security) |  \
               Foreach-Object { \
@@ -80,6 +82,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/nanoserver1809/docker/Dockerfile
+++ b/release/lts/nanoserver1809/docker/Dockerfile
@@ -75,6 +75,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/lts/nanoserver1809/docker/Dockerfile
+++ b/release/lts/nanoserver1809/docker/Dockerfile
@@ -75,7 +75,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
-          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
+          $Env:POWERSHELL_TELEMETRY_OPTOUT=1; `
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/lts/ubuntu16.04/docker/Dockerfile
+++ b/release/lts/ubuntu16.04/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/ubuntu18.04/docker/Dockerfile
+++ b/release/lts/ubuntu18.04/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/lts/windowsservercore/docker/Dockerfile
+++ b/release/lts/windowsservercore/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/lts/windowsservercore/docker/Dockerfile
+++ b/release/lts/windowsservercore/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
-          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
+          $Env:POWERSHELL_TELEMETRY_OPTOUT=1; `
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/preview/alpine311/docker/Dockerfile
+++ b/release/preview/alpine311/docker/Dockerfile
@@ -77,6 +77,7 @@ RUN apk add --no-cache \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/alpine39/docker/Dockerfile
+++ b/release/preview/alpine39/docker/Dockerfile
@@ -83,6 +83,7 @@ RUN apk add --no-cache \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/centos7/docker/Dockerfile
+++ b/release/preview/centos7/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/centos8/docker/Dockerfile
+++ b/release/preview/centos8/docker/Dockerfile
@@ -46,6 +46,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/debian10/docker/Dockerfile
+++ b/release/preview/debian10/docker/Dockerfile
@@ -80,6 +80,7 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/debian11/docker/Dockerfile
+++ b/release/preview/debian11/docker/Dockerfile
@@ -80,6 +80,7 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/debian9/docker/Dockerfile
+++ b/release/preview/debian9/docker/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/fedora/docker/Dockerfile
+++ b/release/preview/fedora/docker/Dockerfile
@@ -42,6 +42,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           try { \$packageList = dnf list installed libmodulemd1} \
           catch {}; \
           \$module = (\$packageList | Select-String -SimpleMatch libmodulemd1);  \
@@ -59,6 +60,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           Write-Host '******* Getting security advisory list *********'; \
           (dnf updateinfo list -q --security) |  \
               Foreach-Object { \
@@ -78,6 +80,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/nanoserver1809/docker/Dockerfile
+++ b/release/preview/nanoserver1809/docker/Dockerfile
@@ -75,6 +75,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/preview/nanoserver1809/docker/Dockerfile
+++ b/release/preview/nanoserver1809/docker/Dockerfile
@@ -75,7 +75,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
-          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
+          $Env:POWERSHELL_TELEMETRY_OPTOUT=1; `
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/preview/ubuntu16.04/docker/Dockerfile
+++ b/release/preview/ubuntu16.04/docker/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/ubuntu18.04/docker/Dockerfile
+++ b/release/preview/ubuntu18.04/docker/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/ubuntu20.04/docker/Dockerfile
+++ b/release/preview/ubuntu20.04/docker/Dockerfile
@@ -77,6 +77,7 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/preview/windowsservercore/docker/Dockerfile
+++ b/release/preview/windowsservercore/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/preview/windowsservercore/docker/Dockerfile
+++ b/release/preview/windowsservercore/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
-          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
+          $Env:POWERSHELL_TELEMETRY_OPTOUT=1; `
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/servicing/centos7/docker/Dockerfile
+++ b/release/servicing/centos7/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/servicing/debian9/docker/Dockerfile
+++ b/release/servicing/debian9/docker/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/servicing/nanoserver1809/docker/Dockerfile
+++ b/release/servicing/nanoserver1809/docker/Dockerfile
@@ -70,6 +70,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/servicing/nanoserver1809/docker/Dockerfile
+++ b/release/servicing/nanoserver1809/docker/Dockerfile
@@ -70,7 +70,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
-          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
+          $Env:POWERSHELL_TELEMETRY_OPTOUT=1; `
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/servicing/opensuse423/docker/Dockerfile
+++ b/release/servicing/opensuse423/docker/Dockerfile
@@ -76,6 +76,7 @@ RUN zypper --non-interactive update --skip-interactive \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/servicing/ubuntu16.04/docker/Dockerfile
+++ b/release/servicing/ubuntu16.04/docker/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/servicing/ubuntu18.04/docker/Dockerfile
+++ b/release/servicing/ubuntu18.04/docker/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/servicing/windowsservercore/docker/Dockerfile
+++ b/release/servicing/windowsservercore/docker/Dockerfile
@@ -52,6 +52,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/servicing/windowsservercore/docker/Dockerfile
+++ b/release/servicing/windowsservercore/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
-          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
+          $Env:POWERSHELL_TELEMETRY_OPTOUT=1; `
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/stable/alpine38/docker/Dockerfile
+++ b/release/stable/alpine38/docker/Dockerfile
@@ -79,6 +79,7 @@ RUN apk add --no-cache \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/alpine39/docker/Dockerfile
+++ b/release/stable/alpine39/docker/Dockerfile
@@ -81,6 +81,7 @@ RUN apk add --no-cache \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/centos8/docker/Dockerfile
+++ b/release/stable/centos8/docker/Dockerfile
@@ -46,6 +46,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/debian10/docker/Dockerfile
+++ b/release/stable/debian10/docker/Dockerfile
@@ -80,6 +80,7 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/debian11/docker/Dockerfile
+++ b/release/stable/debian11/docker/Dockerfile
@@ -80,6 +80,7 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/debian9/docker/Dockerfile
+++ b/release/stable/debian9/docker/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/fedora/docker/Dockerfile
+++ b/release/stable/fedora/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           try { \$packageList = dnf list installed libmodulemd1} \
           catch {}; \
           \$module = (\$packageList | Select-String -SimpleMatch libmodulemd1);  \
@@ -62,6 +63,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           Write-Host '******* Getting security advisory list *********'; \
           (dnf updateinfo list -q --security) |  \
               Foreach-Object { \
@@ -81,6 +83,7 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/nanoserver1809/docker/Dockerfile
+++ b/release/stable/nanoserver1809/docker/Dockerfile
@@ -73,6 +73,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/stable/nanoserver1809/docker/Dockerfile
+++ b/release/stable/nanoserver1809/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
-          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
+          $Env:POWERSHELL_TELEMETRY_OPTOUT=1; `
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/stable/ubuntu16.04/docker/Dockerfile
+++ b/release/stable/ubuntu16.04/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/ubuntu18.04/docker/Dockerfile
+++ b/release/stable/ubuntu18.04/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/release/stable/windowsservercore/docker/Dockerfile
+++ b/release/stable/windowsservercore/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/stable/windowsservercore/docker/Dockerfile
+++ b/release/stable/windowsservercore/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN pwsh `
         -NoLogo `
         -NoProfile `
         -Command " `
-          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
+          $Env:POWERSHELL_TELEMETRY_OPTOUT=1; `
           $stopTime = (get-date).AddMinutes(15); `
           $ErrorActionPreference = 'Stop' ; `
           $ProgressPreference = 'SilentlyContinue' ; `

--- a/release/unstable/oraclelinux/docker/Dockerfile
+++ b/release/unstable/oraclelinux/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN \
         -NoLogo \
         -NoProfile \
         -Command " \
+          \$Env:POWERSHELL_TELEMETRY_OPTOUT=1; \
           \$ErrorActionPreference = 'Stop' ; \
           \$ProgressPreference = 'SilentlyContinue' ; \
           while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \

--- a/tests/containerTestCommon.psm1
+++ b/tests/containerTestCommon.psm1
@@ -463,7 +463,8 @@ function Get-DockerImagePwshPermissions
     $runParams += "ls -l $Path"
 
     $result = Invoke-Docker -Command run -Params $runParams -SuppressHostOutput -PassThru
-    Write-Verbose $result -Verbose
+    # $result may be an array
+    $result | Write-Verbose -Verbose
     return ($result) -split ' ' | select-object -First 1
 }
 


### PR DESCRIPTION
## PR Summary

telemetry should be disabled when running pwsh in a container during setup as it creates a telemetry.uuid file which is then used whenever anyone runs one of our containers.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
