### PR TITLE
Add OpenSSH client package to linux servicing images

### DIFF
--- a/release/servicing/centos7/docker/Dockerfile
+++ b/release/servicing/centos7/docker/Dockerfile
@@ -28,6 +28,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
       gssntlmssp \
       # less is required for help in powershell
       less \
+      # PowerShell remoting over SSH dependencies
+      openssh-clients \
     && yum upgrade-minimal -y --security \
     && yum clean all \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \

--- a/release/servicing/debian9/docker/Dockerfile
+++ b/release/servicing/debian9/docker/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update \
     # required for SSL
         ca-certificates \
         gss-ntlmssp \
+    # PowerShell remoting over SSH dependencies
+        openssh-clients \
     # Download the Linux package and save it
     && echo ${PS_PACKAGE_URL} \
     && curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.deb \

--- a/release/servicing/debian9/docker/Dockerfile
+++ b/release/servicing/debian9/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
         ca-certificates \
         gss-ntlmssp \
     # PowerShell remoting over SSH dependencies
-        openssh-clients \
+        openssh-client \
     # Download the Linux package and save it
     && echo ${PS_PACKAGE_URL} \
     && curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.deb \

--- a/release/servicing/opensuse423/docker/Dockerfile
+++ b/release/servicing/opensuse423/docker/Dockerfile
@@ -60,6 +60,8 @@ RUN zypper --non-interactive update --skip-interactive \
         libicu \
         openssl \
         less \
+        # PowerShell remoting over SSH dependencies
+        openssh-clients \
     && localedef --charmap=UTF-8 --inputfile=en_US $LANG \
     # Create the pwsh symbolic link that points to powershell
     && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \

--- a/release/servicing/ubuntu16.04/docker/Dockerfile
+++ b/release/servicing/ubuntu16.04/docker/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update \
     # required for SSL
         ca-certificates \
         gss-ntlmssp \
+    # PowerShell remoting over SSH dependencies
+        openssh-client \
     # Download the Linux package and save it
     && echo ${PS_PACKAGE_URL} \
     && curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.deb \

--- a/release/servicing/ubuntu18.04/docker/Dockerfile
+++ b/release/servicing/ubuntu18.04/docker/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update \
     # required for SSL
         ca-certificates \
         gss-ntlmssp \
+    # PowerShell remoting over SSH dependencies
+        openssh-client \
     # Download the Linux package and save it
     && echo ${PS_PACKAGE_URL} \
     && curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.deb \


### PR DESCRIPTION
## PR Summary

1. Addresses #374 enhancement request for linux servicing images.

In order to use `Enter-PSSession` to connect with other (Windows or Linux) VM and Container, `OpenSSH` client package is required.

Below is the list of `OpenSSH` client package required for various linux distros:
- `openssh-clients` package for Centos
- `openssh-client` package for Debian
- `openssh-clients` package for openSUSE
- `openssh-client` package for Ubuntu

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/assets/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
