### PR TITLE
Disable telemetry before running pwsh when creating docker image

### DIFF
--- a/release/community-stable/amazonlinux/docker/Dockerfile
+++ b/release/community-stable/amazonlinux/docker/Dockerfile
@@ -49,6 +49,8 @@ RUN \
     # remove powershell package
     && rm -f /tmp/powershell-linux.rpm \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/community-stable/kalilinux/docker/Dockerfile
+++ b/release/community-stable/kalilinux/docker/Dockerfile
@@ -59,6 +59,8 @@ RUN \
     # remove powershell package
     && rm -f /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/community-stable/parrotsec/docker/Dockerfile
+++ b/release/community-stable/parrotsec/docker/Dockerfile
@@ -64,6 +64,8 @@ RUN \
     # Give all user execute permissions and remove write permissions for others
     && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/community-stable/photon/docker/Dockerfile
+++ b/release/community-stable/photon/docker/Dockerfile
@@ -81,6 +81,8 @@ RUN \
     # Give all user execute permissions and remove write permissions for others
     && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/alpine39/docker/Dockerfile
+++ b/release/lts/alpine39/docker/Dockerfile
@@ -79,6 +79,8 @@ RUN apk add --no-cache \
     # Give all user execute permissions and remove write permissions for others
     && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/centos7/docker/Dockerfile
+++ b/release/lts/centos7/docker/Dockerfile
@@ -40,6 +40,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     # remove powershell package
     && rm /tmp/powershell.rpm \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/centos8/docker/Dockerfile
+++ b/release/lts/centos8/docker/Dockerfile
@@ -41,6 +41,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     # remove powershell package
     && rm /tmp/powershell.rpm \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/debian10/docker/Dockerfile
+++ b/release/lts/debian10/docker/Dockerfile
@@ -78,6 +78,8 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # Create the pwsh-lts symbolic link that points to powershell
     && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh-lts \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/debian11/docker/Dockerfile
+++ b/release/lts/debian11/docker/Dockerfile
@@ -76,6 +76,8 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # Create the pwsh-lts symbolic link that points to powershell
     && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh-lts \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/debian9/docker/Dockerfile
+++ b/release/lts/debian9/docker/Dockerfile
@@ -44,6 +44,8 @@ RUN apt-get update \
     # remove powershell package
     && rm /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/fedora/docker/Dockerfile
+++ b/release/lts/fedora/docker/Dockerfile
@@ -40,6 +40,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     && echo "starting FEDORA-2019-27e7b92407" \
     # For whatever reason FEDORA-2019-27e7b92407 has to be patched manually
     # to do this, upgrade libmodulemd1, if it is installed
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/nanoserver1809/docker/Dockerfile
+++ b/release/lts/nanoserver1809/docker/Dockerfile
@@ -14,6 +14,9 @@ ARG PS_VERSION=7.0.0-rc.1
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
+# disable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="1"
+
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
@@ -83,5 +86,8 @@ RUN pwsh `
             if((get-date) -gt $stopTime) { throw 'timout expired'} `
             Start-Sleep -Seconds 6 ; `
           }"
+
+# re-enable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 
 CMD ["pwsh.exe"]

--- a/release/lts/ubuntu16.04/docker/Dockerfile
+++ b/release/lts/ubuntu16.04/docker/Dockerfile
@@ -41,6 +41,8 @@ RUN apt-get update \
     # remove powershell package
     && rm /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/ubuntu18.04/docker/Dockerfile
+++ b/release/lts/ubuntu18.04/docker/Dockerfile
@@ -41,6 +41,8 @@ RUN apt-get update \
     # remove powershell package
     && rm /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/lts/windowsservercore/docker/Dockerfile
+++ b/release/lts/windowsservercore/docker/Dockerfile
@@ -40,7 +40,8 @@ ENV ProgramFiles="C:\Program Files" `
     PSModuleAnalysisCachePath="$LOCALAPPDATA\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" `
     # Persist %PSCORE% ENV variable for user convenience
     PSCORE="$ProgramFiles\PowerShell\pwsh.exe" `
-    POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-WindowsServerCore-${fromTag}"
+    POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-WindowsServerCore-${fromTag}" 1
+    POWERSHELL_TELEMETRY_OPTOUT="1"
 
 # Copy PowerShell Core from the installer container
 COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell\\latest"]
@@ -61,5 +62,8 @@ RUN pwsh `
             if((get-date) -gt $stopTime) { throw 'timout expired'} `
             Start-Sleep -Seconds 6 ; `
           }"
+
+# re-enable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 
 CMD ["pwsh.exe"]

--- a/release/lts/windowsservercore/docker/Dockerfile
+++ b/release/lts/windowsservercore/docker/Dockerfile
@@ -40,7 +40,7 @@ ENV ProgramFiles="C:\Program Files" `
     PSModuleAnalysisCachePath="$LOCALAPPDATA\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" `
     # Persist %PSCORE% ENV variable for user convenience
     PSCORE="$ProgramFiles\PowerShell\pwsh.exe" `
-    POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-WindowsServerCore-${fromTag}" 1
+    POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-WindowsServerCore-${fromTag}" `
     POWERSHELL_TELEMETRY_OPTOUT="1"
 
 # Copy PowerShell Core from the installer container

--- a/release/preview/alpine311/docker/Dockerfile
+++ b/release/preview/alpine311/docker/Dockerfile
@@ -73,6 +73,8 @@ RUN apk add --no-cache \
     # Give all user execute permissions and remove write permissions for others
     && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/alpine39/docker/Dockerfile
+++ b/release/preview/alpine39/docker/Dockerfile
@@ -75,6 +75,8 @@ RUN apk add --no-cache \
     # Give all user execute permissions and remove write permissions for others
     && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/centos7/docker/Dockerfile
+++ b/release/preview/centos7/docker/Dockerfile
@@ -41,6 +41,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     && rm /tmp/powershell.rpm \
     && ln -sf /opt/microsoft/powershell/7-preview/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/centos8/docker/Dockerfile
+++ b/release/preview/centos8/docker/Dockerfile
@@ -42,6 +42,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     && rm /tmp/powershell.rpm \
     && ln -sf /opt/microsoft/powershell/7-preview/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/debian10/docker/Dockerfile
+++ b/release/preview/debian10/docker/Dockerfile
@@ -76,6 +76,8 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # Create the pwsh symbolic link that points to powershell
     && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/debian11/docker/Dockerfile
+++ b/release/preview/debian11/docker/Dockerfile
@@ -74,6 +74,8 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # Create the pwsh symbolic link that points to powershell
     && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/debian11/meta.json
+++ b/release/preview/debian11/meta.json
@@ -15,7 +15,7 @@
     ],
     "SubImage": "test-deps",
     "TestProperties": {
-        "size": 330
+        "size": 350
     }
 }
 

--- a/release/preview/debian9/docker/Dockerfile
+++ b/release/preview/debian9/docker/Dockerfile
@@ -45,6 +45,8 @@ RUN apt-get update \
     && rm /tmp/powershell.deb \
     && ln -sf /opt/microsoft/powershell/7-preview/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/fedora/docker/Dockerfile
+++ b/release/preview/fedora/docker/Dockerfile
@@ -38,6 +38,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     && echo "starting FEDORA-2019-27e7b92407" \
     # For whatever reason FEDORA-2019-27e7b92407 has to be patched manually
     # to do this, upgrade libmodulemd1, if it is installed
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/nanoserver1809/docker/Dockerfile
+++ b/release/preview/nanoserver1809/docker/Dockerfile
@@ -14,6 +14,9 @@ ARG PS_VERSION=7.0.0-rc.1
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
+# disable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="1"
+
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
@@ -83,5 +86,8 @@ RUN pwsh `
             if((get-date) -gt $stopTime) { throw 'timout expired'} `
             Start-Sleep -Seconds 6 ; `
           }"
+
+# re-enable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 
 CMD ["pwsh.exe"]

--- a/release/preview/ubuntu16.04/docker/Dockerfile
+++ b/release/preview/ubuntu16.04/docker/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update \
     && rm /tmp/powershell.deb \
     && ln -sf /opt/microsoft/powershell/7-preview/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/ubuntu18.04/docker/Dockerfile
+++ b/release/preview/ubuntu18.04/docker/Dockerfile
@@ -42,6 +42,8 @@ RUN apt-get update \
     && rm /tmp/powershell.deb \
     && ln -sf /opt/microsoft/powershell/7-preview/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/ubuntu20.04/docker/Dockerfile
+++ b/release/preview/ubuntu20.04/docker/Dockerfile
@@ -73,6 +73,8 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # Create the pwsh symbolic link that points to powershell
     && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/preview/windowsservercore/docker/Dockerfile
+++ b/release/preview/windowsservercore/docker/Dockerfile
@@ -40,7 +40,8 @@ ENV ProgramFiles="C:\Program Files" `
     PSModuleAnalysisCachePath="$LOCALAPPDATA\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" `
     # Persist %PSCORE% ENV variable for user convenience
     PSCORE="$ProgramFiles\PowerShell\pwsh.exe" `
-    POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-WindowsServerCore-${fromTag}"
+    POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-WindowsServerCore-${fromTag}" `
+    POWERSHELL_TELEMETRY_OPTOUT="1"
 
 # Copy PowerShell Core from the installer container
 COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell\\latest"]
@@ -61,5 +62,8 @@ RUN pwsh `
             if((get-date) -gt $stopTime) { throw 'timout expired'} `
             Start-Sleep -Seconds 6 ; `
           }"
+
+# re-enable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 
 CMD ["pwsh.exe"]

--- a/release/servicing/centos7/docker/Dockerfile
+++ b/release/servicing/centos7/docker/Dockerfile
@@ -36,6 +36,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     # remove powershell package
     && rm /tmp/powershell.rpm \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/servicing/debian9/docker/Dockerfile
+++ b/release/servicing/debian9/docker/Dockerfile
@@ -43,6 +43,8 @@ RUN apt-get update \
     # remove powershell package
     && rm /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/servicing/nanoserver1809/docker/Dockerfile
+++ b/release/servicing/nanoserver1809/docker/Dockerfile
@@ -14,6 +14,9 @@ ARG PS_VERSION=6.2.0
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
+# disable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="1"
+
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
@@ -78,5 +81,8 @@ RUN pwsh `
             if((get-date) -gt $stopTime) { throw 'timout expired'} `
             Start-Sleep -Seconds 6 ; `
           }"
+
+# re-enable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 
 CMD ["pwsh.exe"]

--- a/release/servicing/opensuse423/docker/Dockerfile
+++ b/release/servicing/opensuse423/docker/Dockerfile
@@ -72,6 +72,8 @@ RUN zypper --non-interactive update --skip-interactive \
     # remove package manager log file
     && rm -f /var/log/zypp/history /var/log/zypper.log \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/servicing/ubuntu16.04/docker/Dockerfile
+++ b/release/servicing/ubuntu16.04/docker/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update \
     # remove powershell package
     && rm /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/servicing/ubuntu18.04/docker/Dockerfile
+++ b/release/servicing/ubuntu18.04/docker/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update \
     # remove powershell package
     && rm /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/servicing/windowsservercore/docker/Dockerfile
+++ b/release/servicing/windowsservercore/docker/Dockerfile
@@ -39,7 +39,8 @@ ENV ProgramFiles="C:\Program Files" `
     LOCALAPPDATA="C:\Users\ContainerAdministrator\AppData\Local" `
     PSModuleAnalysisCachePath="$LOCALAPPDATA\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" `
     # Persist %PSCORE% ENV variable for user convenience
-    PSCORE="$ProgramFiles\PowerShell\pwsh.exe"
+    PSCORE="$ProgramFiles\PowerShell\pwsh.exe" `
+    POWERSHELL_TELEMETRY_OPTOUT="1"
 
 # Copy PowerShell Core from the installer container
 COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell\\latest"]
@@ -60,5 +61,8 @@ RUN pwsh `
             if((get-date) -gt $stopTime) { throw 'timout expired'} `
             Start-Sleep -Seconds 6 ; `
           }"
+
+# re-enable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 
 CMD ["pwsh.exe"]

--- a/release/stable/alpine38/docker/Dockerfile
+++ b/release/stable/alpine38/docker/Dockerfile
@@ -75,6 +75,8 @@ RUN apk add --no-cache \
     # Give all user execute permissions and remove write permissions for others
     && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/alpine39/docker/Dockerfile
+++ b/release/stable/alpine39/docker/Dockerfile
@@ -73,6 +73,8 @@ RUN apk add --no-cache \
     # Give all user execute permissions and remove write permissions for others
     && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/centos7/docker/Dockerfile
+++ b/release/stable/centos7/docker/Dockerfile
@@ -36,6 +36,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     # remove powershell package
     && rm /tmp/powershell.rpm \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/centos8/docker/Dockerfile
+++ b/release/stable/centos8/docker/Dockerfile
@@ -42,6 +42,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     && rm /tmp/powershell.rpm \
     && ln -sf /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/debian10/docker/Dockerfile
+++ b/release/stable/debian10/docker/Dockerfile
@@ -76,6 +76,8 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # Create the pwsh symbolic link that points to powershell
     && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/debian11/docker/Dockerfile
+++ b/release/stable/debian11/docker/Dockerfile
@@ -74,6 +74,8 @@ RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # Create the pwsh symbolic link that points to powershell
     && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/debian9/docker/Dockerfile
+++ b/release/stable/debian9/docker/Dockerfile
@@ -43,6 +43,8 @@ RUN apt-get update \
     # remove powershell package
     && rm /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/fedora/docker/Dockerfile
+++ b/release/stable/fedora/docker/Dockerfile
@@ -41,6 +41,8 @@ RUN curl -sSL ${PS_PACKAGE_URL} -o /tmp/powershell.rpm \
     && echo "starting FEDORA-2019-27e7b92407" \
     # For whatever reason FEDORA-2019-27e7b92407 has to be patched manually
     # to do this, upgrade libmodulemd1, if it is installed
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/nanoserver1809/docker/Dockerfile
+++ b/release/stable/nanoserver1809/docker/Dockerfile
@@ -16,6 +16,9 @@ ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# disable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="1"
+
 ARG PS_PACKAGE_URL_BASE64
 
 RUN Write-host "Verifying valid Version..."; `
@@ -81,5 +84,8 @@ RUN pwsh `
             if((get-date) -gt $stopTime) { throw 'timout expired'} `
             Start-Sleep -Seconds 6 ; `
           }"
+
+# re-enable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 
 CMD ["pwsh.exe"]

--- a/release/stable/ubuntu16.04/docker/Dockerfile
+++ b/release/stable/ubuntu16.04/docker/Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get update \
     # remove powershell package
     && rm /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/ubuntu18.04/docker/Dockerfile
+++ b/release/stable/ubuntu18.04/docker/Dockerfile
@@ -41,6 +41,8 @@ RUN apt-get update \
     # remove powershell package
     && rm /tmp/powershell.deb \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/stable/windowsservercore/docker/Dockerfile
+++ b/release/stable/windowsservercore/docker/Dockerfile
@@ -41,7 +41,7 @@ ENV ProgramFiles="C:\Program Files" `
     # Persist %PSCORE% ENV variable for user convenience
     PSCORE="$ProgramFiles\PowerShell\pwsh.exe" `
     POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-WindowsServerCore-${fromTag}" `
-    POWERSHELL_TELEMETRY_OPTOUT="0"
+    POWERSHELL_TELEMETRY_OPTOUT="1"
 
 # Copy PowerShell Core from the installer container
 COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell\\latest"]

--- a/release/stable/windowsservercore/docker/Dockerfile
+++ b/release/stable/windowsservercore/docker/Dockerfile
@@ -40,7 +40,8 @@ ENV ProgramFiles="C:\Program Files" `
     PSModuleAnalysisCachePath="$LOCALAPPDATA\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" `
     # Persist %PSCORE% ENV variable for user convenience
     PSCORE="$ProgramFiles\PowerShell\pwsh.exe" `
-    POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-WindowsServerCore-${fromTag}"
+    POWERSHELL_DISTRIBUTION_CHANNEL="PSDocker-WindowsServerCore-${fromTag}" `
+    POWERSHELL_TELEMETRY_OPTOUT="0"
 
 # Copy PowerShell Core from the installer container
 COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell\\latest"]
@@ -61,5 +62,8 @@ RUN pwsh `
             if((get-date) -gt $stopTime) { throw 'timout expired'} `
             Start-Sleep -Seconds 6 ; `
           }"
+
+# re-enable telemetry
+ENV POWERSHELL_TELEMETRY_OPTOUT="0"
 
 CMD ["pwsh.exe"]

--- a/release/unstable/archlinux/docker/Dockerfile
+++ b/release/unstable/archlinux/docker/Dockerfile
@@ -97,6 +97,8 @@ RUN \
     # Give all user execute permissions and remove write permissions for others
     && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/unstable/blackarch/docker/Dockerfile
+++ b/release/unstable/blackarch/docker/Dockerfile
@@ -112,6 +112,8 @@ RUN \
     # Give all user execute permissions and remove write permissions for others
     && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/unstable/clearlinux/docker/Dockerfile
+++ b/release/unstable/clearlinux/docker/Dockerfile
@@ -43,6 +43,8 @@ RUN \
     # Create the pwsh symbolic link that points to powershell
     && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \

--- a/release/unstable/oraclelinux/docker/Dockerfile
+++ b/release/unstable/oraclelinux/docker/Dockerfile
@@ -49,6 +49,8 @@ RUN \
     # remove powershell package
     && rm -f /tmp/powershell-linux.rpm \
     # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
     && pwsh \
         -NoLogo \
         -NoProfile \


### PR DESCRIPTION
In the case of windows, we need to re-enable telemetry

## PR Summary

we need to have telemetry disabled when creating command cache because the telemetry.uuid file is created and **all** the containers have the same id so we can't disambiguate them.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
  - [x] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
