### PR TITLE
remove usage of `fromtag`

### DIFF
--- a/release/community-stable/amazonlinux/test-deps/docker/Dockerfile
+++ b/release/community-stable/amazonlinux/test-deps/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. 
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
 # Docker image file that describes an Amazon Linux image with PowerShell
@@ -8,8 +8,6 @@
 ARG BaseImage=pshorg/powershellcommunity:amazonlinux-2.0
 
 FROM ${BaseImage}
-
-ARG fromTag=2.0.20181010
 
 # Installation
 RUN \
@@ -30,6 +28,6 @@ RUN \
     # remove cache folders and files
     && rm -rf /var/cache/yum
 
-ENV POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-AmazonLinux-${fromTag}
+ENV POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-AmazonLinux
 
 CMD [ "pwsh" ]

--- a/release/community-stable/kalilinux/docker/Dockerfile
+++ b/release/community-stable/kalilinux/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. 
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
 # Docker image file that describes an Kali Rolling image with PowerShell
@@ -26,7 +26,7 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     # Invoke-WebRequest : Authentication failed" issue when executing using
     # docker run [OPTIONS] IMAGE[:TAG|@DIGEST] [Invoke-WebRequest] [-Uri <HTTPS URL>]
     DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=0 \
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-KaliLinux-${fromTag}
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-KaliLinux
 
 # Installation
 RUN \

--- a/release/preview/alpine310/docker/Dockerfile
+++ b/release/preview/alpine310/docker/Dockerfile
@@ -26,8 +26,6 @@ RUN tar zxf /tmp/linux.tar.gz -C ${PS_INSTALL_FOLDER} -v
 # Start a new stage so we lose all the tar.gz layers from the final image
 FROM alpine:3.10
 
-ARG fromTag=3.10
-
 # Copy only the files we need from the previous stage
 COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
 
@@ -41,8 +39,7 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     LANG=en_US.UTF-8 \
     # set a fixed location for the Module analysis cache
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-Alpine-${fromTag}
-
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-Alpine-3.10
 # Install dotnet dependencies and ca-certificates
 RUN apk add --no-cache \
     ca-certificates \

--- a/release/preview/alpine310/test-deps/docker/Dockerfile
+++ b/release/preview/alpine310/test-deps/docker/Dockerfile
@@ -8,12 +8,10 @@ FROM node:14.3.0-alpine as node
 
 FROM ${BaseImage}
 
-ARG fromTag=3.9
-
 ENV NODE_VERSION=14.3.0 \
     YARN_VERSION=1.22.4 \
     NVM_DIR="/root/.nvm" \
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-Alpine-${fromTag}
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-Alpine-3.9
 
 # workaround for Alpine to run in Azure DevOps
 ENV NODE_NO_WARNINGS=1

--- a/release/preview/alpine311/test-deps/docker/Dockerfile
+++ b/release/preview/alpine311/test-deps/docker/Dockerfile
@@ -8,12 +8,10 @@ FROM node:14.3.0-alpine as node
 
 FROM ${BaseImage}
 
-ARG fromTag=3.11
-
 ENV NODE_VERSION=14.3.0 \
     YARN_VERSION=1.22.4 \
     NVM_DIR="/root/.nvm" \
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-Alpine-${fromTag}
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-Alpine-3.11
 
 # workaround for Alpine to run in Azure DevOps
 ENV NODE_NO_WARNINGS=1


### PR DESCRIPTION
## PR Summary

remove usage of `fromtag`
These images use the new system where `fromtag` is not used

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
