### PR TITLE
merge preview into stable for 7.1 release for windows images

### DIFF
--- a/release/preview/nanoserver1809/docker/Dockerfile
+++ b/release/preview/nanoserver1809/docker/Dockerfile
@@ -13,10 +13,10 @@ ARG PS_VERSION=7.0.0-rc.1
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
 # disable telemetry
 ENV POWERSHELL_TELEMETRY_OPTOUT="1"
-
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 
@@ -40,8 +40,6 @@ RUN Write-host "Verifying valid Version..."; `
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:1809
-
-ARG IMAGE_NAME=mcr.microsoft.com/powershell
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/preview/nanoserver1903/docker/Dockerfile
+++ b/release/preview/nanoserver1903/docker/Dockerfile
@@ -13,10 +13,10 @@ ARG PS_VERSION=7.0.0-rc.1
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
 # disable telemetry
 ENV POWERSHELL_TELEMETRY_OPTOUT="1"
-
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 
@@ -40,8 +40,6 @@ RUN Write-host "Verifying valid Version..."; `
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:1903
-
-ARG IMAGE_NAME=mcr.microsoft.com/powershell
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/preview/nanoserver1909/docker/Dockerfile
+++ b/release/preview/nanoserver1909/docker/Dockerfile
@@ -13,10 +13,10 @@ ARG PS_VERSION=7.0.0-rc.1
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
 # disable telemetry
 ENV POWERSHELL_TELEMETRY_OPTOUT="1"
-
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 
@@ -40,8 +40,6 @@ RUN Write-host "Verifying valid Version..."; `
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:1909
-
-ARG IMAGE_NAME=mcr.microsoft.com/powershell
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/preview/nanoserver2004/dependabot/Dockerfile
+++ b/release/preview/nanoserver2004/dependabot/Dockerfile
@@ -1,6 +1,0 @@
-# Copyright (c) Microsoft Corporation. 
-# Licensed under the MIT License.
-
-# Dummy docker image to trigger dependabot PRs
-
-FROM mcr.microsoft.com/windows/nanoserver:2004

--- a/release/preview/nanoserver2004/docker/Dockerfile
+++ b/release/preview/nanoserver2004/docker/Dockerfile
@@ -13,10 +13,10 @@ ARG PS_VERSION=7.0.0-rc.1
 
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
 # disable telemetry
 ENV POWERSHELL_TELEMETRY_OPTOUT="1"
-
-SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ARG PS_PACKAGE_URL_BASE64
 
@@ -40,8 +40,6 @@ RUN Write-host "Verifying valid Version..."; `
 
 # Install PowerShell into NanoServer
 FROM ${NanoServerRepo}:2004
-
-ARG IMAGE_NAME=mcr.microsoft.com/powershell
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/preview/windowsservercore2004/dependabot/Dockerfile
+++ b/release/preview/windowsservercore2004/dependabot/Dockerfile
@@ -1,6 +1,0 @@
-# Copyright (c) Microsoft Corporation. 
-# Licensed under the MIT License.
-
-# Dummy docker image to trigger dependabot PRs
-
-FROM mcr.microsoft.com/windows/servercore:2004

--- a/release/stable/nanoserver1809/docker/Dockerfile
+++ b/release/stable/nanoserver1809/docker/Dockerfile
@@ -1,6 +1,7 @@
+# escape=`
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# escape=`
+
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
 ARG InstallerRepo=mcr.microsoft.com/powershell

--- a/release/stable/nanoserver1809/docker/Dockerfile
+++ b/release/stable/nanoserver1809/docker/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # escape=`
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver

--- a/release/stable/nanoserver1903/docker/Dockerfile
+++ b/release/stable/nanoserver1903/docker/Dockerfile
@@ -1,6 +1,7 @@
+# escape=`
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# escape=`
+
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
 ARG InstallerRepo=mcr.microsoft.com/powershell

--- a/release/stable/nanoserver1903/docker/Dockerfile
+++ b/release/stable/nanoserver1903/docker/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # escape=`
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver

--- a/release/stable/nanoserver1909/docker/Dockerfile
+++ b/release/stable/nanoserver1909/docker/Dockerfile
@@ -1,6 +1,7 @@
+# escape=`
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# escape=`
+
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
 ARG InstallerRepo=mcr.microsoft.com/powershell

--- a/release/stable/nanoserver1909/docker/Dockerfile
+++ b/release/stable/nanoserver1909/docker/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # escape=`
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver

--- a/release/stable/nanoserver2004/docker/Dockerfile
+++ b/release/stable/nanoserver2004/docker/Dockerfile
@@ -1,6 +1,7 @@
+# escape=`
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# escape=`
+
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
 ARG InstallerRepo=mcr.microsoft.com/powershell

--- a/release/stable/nanoserver2004/docker/Dockerfile
+++ b/release/stable/nanoserver2004/docker/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # escape=`
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver

--- a/release/stable/windowsservercore1809/docker/Dockerfile
+++ b/release/stable/windowsservercore1809/docker/Dockerfile
@@ -1,6 +1,7 @@
+# escape=`
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# escape=`
+
 ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
 
 # Use server core as an installer container to extract PowerShell,

--- a/release/stable/windowsservercore1809/docker/Dockerfile
+++ b/release/stable/windowsservercore1809/docker/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # escape=`
 ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
 

--- a/release/stable/windowsservercore1903/docker/Dockerfile
+++ b/release/stable/windowsservercore1903/docker/Dockerfile
@@ -1,6 +1,7 @@
+# escape=`
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# escape=`
+
 ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
 
 # Use server core as an installer container to extract PowerShell,

--- a/release/stable/windowsservercore1903/docker/Dockerfile
+++ b/release/stable/windowsservercore1903/docker/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # escape=`
 ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
 

--- a/release/stable/windowsservercore1909/docker/Dockerfile
+++ b/release/stable/windowsservercore1909/docker/Dockerfile
@@ -1,6 +1,7 @@
+# escape=`
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# escape=`
+
 ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
 
 # Use server core as an installer container to extract PowerShell,

--- a/release/stable/windowsservercore1909/docker/Dockerfile
+++ b/release/stable/windowsservercore1909/docker/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # escape=`
 ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
 

--- a/release/stable/windowsservercore2004/docker/Dockerfile
+++ b/release/stable/windowsservercore2004/docker/Dockerfile
@@ -1,6 +1,7 @@
+# escape=`
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# escape=`
+
 ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
 
 # Use server core as an installer container to extract PowerShell,

--- a/release/stable/windowsservercore2004/docker/Dockerfile
+++ b/release/stable/windowsservercore2004/docker/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # escape=`
 ARG WindowsServerCoreRepo=mcr.microsoft.com/windows/servercore
 


### PR DESCRIPTION
## PR Summary

Merge changes from preview into stable for windows images, specifically nanoserver and windowscoreserver. Modified Dockerfiles and meta.json files for these images and removed their dependabot folders.
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
