### PR TITLE
remove references to outdated dependencies from preview dockerfiles

### DIFF
--- a/release/preview/arm32v7/docker/Dockerfile
+++ b/release/preview/arm32v7/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. 
+# Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
 FROM arm32v7/ubuntu:bionic AS installer-env
@@ -58,7 +58,7 @@ COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershe
 
 RUN \
   apt-get update \
-  && apt-get install --no-install-recommends ca-certificates libunwind8 libssl1.0 libicu60 less --yes
+  && apt-get install --no-install-recommends ca-certificates libssl1.0 libicu60 less --yes
 
     # Give all user execute permissions and remove write permissions for others
 RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \

--- a/release/preview/debian10/docker/Dockerfile
+++ b/release/preview/debian10/docker/Dockerfile
@@ -60,7 +60,6 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        liblttng-ust0 \
         libstdc++6 \
         zlib1g \
     # PowerShell remoting over SSH dependencies

--- a/release/preview/debian11/docker/Dockerfile
+++ b/release/preview/debian11/docker/Dockerfile
@@ -59,7 +59,6 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        liblttng-ust0 \
         libstdc++6 \
         zlib1g \
     # PowerShell remoting over SSH dependencies

--- a/release/preview/ubuntu20.04/docker/Dockerfile
+++ b/release/preview/ubuntu20.04/docker/Dockerfile
@@ -60,7 +60,6 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        liblttng-ust0 \
         libstdc++6 \
         zlib1g \
     # PowerShell remoting over SSH dependencies


### PR DESCRIPTION
## PR Summary
removed outdated linux dependencies from preview images' dockerfiles. Outdated linux dependencies include: liblttng-ust0, libcurl3, libunwind8, libuuid1. 

This PR goes along with the PR in PowerShell [here](https://github.com/PowerShell/PowerShell/pull/14688)
<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
