### PR TITLE
update buildHelper to check if isBroken tag present

### DIFF
--- a/tools/buildHelper/buildHelper.psm1
+++ b/tools/buildHelper/buildHelper.psm1
@@ -449,7 +449,7 @@ function Get-DockerImageMetaDataWrapper
 
     # if the image is broken and we shouldn't include known issues,
     # do this
-    if(!$IncludeKnownIssues.IsPresent -and $meta.Broken -ne $null) {
+    if( !$IncludeKnownIssues.IsPresent -and $meta.IsBroken) {
         return
     }
 


### PR DESCRIPTION
For images that we know are broken but still wish to make available (just not publish) we include a `isBroken` tag in their meta.json file. In the buildHelper script we check for this tag from the metadata and if found to be true we throw away the image during the build.

- fix typo in buildHelper to check isBroken tag.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
