### PR TITLE
Public 2022 images

### DIFF
--- a/release/lts/nanoserver2022/docker/Dockerfile
+++ b/release/lts/nanoserver2022/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM mcr.microsoft.com/windows/server:${tag}
+FROM mcr.microsoft.com/windows/nanoserver:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/lts/nanoserver2022/docker/Dockerfile
+++ b/release/lts/nanoserver2022/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM mcr.microsoft.com/windows/nanoserver:${tag}
+FROM mcr.microsoft.com/${NanoServerRepo}:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/lts/nanoserver2022/docker/Dockerfile
+++ b/release/lts/nanoserver2022/docker/Dockerfile
@@ -6,7 +6,7 @@
 ARG InstallerVersion=nanoserver
 ARG dockerHost=mcr.microsoft.com
 ARG InstallerRepo=mcr.microsoft.com/powershell
-ARG NanoServerRepo=windows/nanoserver
+ARG NanoServerRepo=windows/server
 ARG tag=ltsc2022
 
 # Use server core as an installer container to extract PowerShell,

--- a/release/lts/nanoserver2022/docker/Dockerfile
+++ b/release/lts/nanoserver2022/docker/Dockerfile
@@ -4,9 +4,9 @@
 
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
-ARG dockerHost=mcr.microsoft.com
+ARG dockerHost=mcr.microsoft.com/windows/server
 ARG InstallerRepo=mcr.microsoft.com/powershell
-ARG NanoServerRepo=windows/server
+ARG NanoServerRepo=windows/nanoserver
 ARG tag=ltsc2022
 
 # Use server core as an installer container to extract PowerShell,
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM ${dockerHost}/${NanoServerRepo}:${tag}
+FROM ${dockerHost}:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/lts/nanoserver2022/docker/Dockerfile
+++ b/release/lts/nanoserver2022/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
-ARG dockerHost=mcr.microsoft.com/windows/server
+ARG dockerHost=mcr.microsoft.com
 ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=windows/nanoserver
 ARG tag=ltsc2022
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM ${dockerHost}:${tag}
+FROM mcr.microsoft.com/windows/server:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/lts/nanoserver2022/meta.json
+++ b/release/lts/nanoserver2022/meta.json
@@ -19,6 +19,5 @@
     "TestProperties": {
         "size": 1
     },
-    "UseAcr": true,
-    "IsPrivate": true
+    "UseAcr": true
 }

--- a/release/lts/windowsservercore2022/docker/Dockerfile
+++ b/release/lts/windowsservercore2022/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG tag=ltsc2022
 
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away
-FROM ${dockerHost}/${WindowsServerCoreRepo}:${tag} AS installer-env
+FROM mcr.microsoft.com/${WindowsServerCoreRepo}:${tag} AS installer-env
 
 ARG PS_VERSION=6.2.0
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/PowerShell-${PS_VERSION}-win-x64.zip
@@ -35,7 +35,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive powershell.zip -DestinationPath  \PowerShell
 
 # Install PowerShell into WindowsServerCore
-FROM ${dockerHost}/${WindowsServerCoreRepo}:${tag}
+FROM mcr.microsoft.com/${WindowsServerCoreRepo}:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/lts/windowsservercore2022/meta.json
+++ b/release/lts/windowsservercore2022/meta.json
@@ -19,6 +19,5 @@
     "TestProperties": {
         "size": 1
     },
-    "UseAcr": true,
-    "IsPrivate": true
+    "UseAcr": true
 }

--- a/release/preview/nanoserver2022/docker/Dockerfile
+++ b/release/preview/nanoserver2022/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM mcr.microsoft.com/windows/server:${tag}
+FROM mcr.microsoft.com/windows/nanoserver:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/preview/nanoserver2022/docker/Dockerfile
+++ b/release/preview/nanoserver2022/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM mcr.microsoft.com/windows/nanoserver:${tag}
+FROM mcr.microsoft.com/${NanoServerRepo}:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/preview/nanoserver2022/docker/Dockerfile
+++ b/release/preview/nanoserver2022/docker/Dockerfile
@@ -6,7 +6,7 @@
 ARG InstallerVersion=nanoserver
 ARG dockerHost=mcr.microsoft.com
 ARG InstallerRepo=mcr.microsoft.com/powershell
-ARG NanoServerRepo=windows/nanoserver
+ARG NanoServerRepo=windows/server
 ARG tag=ltsc2022
 
 # Use server core as an installer container to extract PowerShell,

--- a/release/preview/nanoserver2022/docker/Dockerfile
+++ b/release/preview/nanoserver2022/docker/Dockerfile
@@ -4,9 +4,9 @@
 
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
-ARG dockerHost=mcr.microsoft.com
+ARG dockerHost=mcr.microsoft.com/windows/server
 ARG InstallerRepo=mcr.microsoft.com/powershell
-ARG NanoServerRepo=windows/server
+ARG NanoServerRepo=windows/nanoserver
 ARG tag=ltsc2022
 
 # Use server core as an installer container to extract PowerShell,
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM ${dockerHost}/${NanoServerRepo}:${tag}
+FROM ${dockerHost}:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/preview/nanoserver2022/docker/Dockerfile
+++ b/release/preview/nanoserver2022/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
-ARG dockerHost=mcr.microsoft.com/windows/server
+ARG dockerHost=mcr.microsoft.com
 ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=windows/nanoserver
 ARG tag=ltsc2022
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM ${dockerHost}:${tag}
+FROM mcr.microsoft.com/windows/server:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/preview/nanoserver2022/meta.json
+++ b/release/preview/nanoserver2022/meta.json
@@ -16,6 +16,5 @@
     "TestProperties": {
         "size": 1
     },
-    "UseAcr": true,
-    "IsPrivate": true
+    "UseAcr": true
 }

--- a/release/preview/windowsservercore2022/docker/Dockerfile
+++ b/release/preview/windowsservercore2022/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG tag=ltsc2022
 
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away
-FROM ${dockerHost}/${WindowsServerCoreRepo}:${tag} AS installer-env
+FROM mcr.microsoft.com/${WindowsServerCoreRepo}:${tag} AS installer-env
 
 ARG PS_VERSION=6.2.0
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/PowerShell-${PS_VERSION}-win-x64.zip
@@ -35,7 +35,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive powershell.zip -DestinationPath  \PowerShell
 
 # Install PowerShell into WindowsServerCore
-FROM ${dockerHost}/${WindowsServerCoreRepo}:${tag}
+FROM mcr.microsoft.com/${WindowsServerCoreRepo}:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/preview/windowsservercore2022/meta.json
+++ b/release/preview/windowsservercore2022/meta.json
@@ -16,6 +16,5 @@
     "TestProperties": {
         "size": 1
     },
-    "UseAcr": true,
-    "IsPrivate": true
+    "UseAcr": true
 }

--- a/release/stable/nanoserver2022/docker/Dockerfile
+++ b/release/stable/nanoserver2022/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM mcr.microsoft.com/windows/nanoserver:${tag}
+FROM mcr.microsoft.com/${NanoServerRepo}:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/stable/nanoserver2022/docker/Dockerfile
+++ b/release/stable/nanoserver2022/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM mcr.microsoft.com/windows/servercore:${tag}
+FROM mcr.microsoft.com/windows/nanoserver:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/stable/nanoserver2022/docker/Dockerfile
+++ b/release/stable/nanoserver2022/docker/Dockerfile
@@ -4,9 +4,9 @@
 
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
-ARG dockerHost=mcr.microsoft.com
+ARG dockerHost=mcr.microsoft.com/windows/server
 ARG InstallerRepo=mcr.microsoft.com/powershell
-ARG NanoServerRepo=windows/server
+ARG NanoServerRepo=windows/nanoserver
 ARG tag=ltsc2022
 
 # Use server core as an installer container to extract PowerShell,
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM ${dockerHost}/${NanoServerRepo}:${tag}
+FROM ${dockerHost}:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/stable/nanoserver2022/docker/Dockerfile
+++ b/release/stable/nanoserver2022/docker/Dockerfile
@@ -9,8 +9,6 @@ ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=windows/server
 ARG tag=ltsc2022
 
-#mcr.microsoft.com/windows/server:ltsc2022
-
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away
 FROM ${InstallerRepo}:$InstallerVersion  AS installer-env

--- a/release/stable/nanoserver2022/docker/Dockerfile
+++ b/release/stable/nanoserver2022/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM mcr.microsoft.com/windows/server:${tag}
+FROM mcr.microsoft.com/windows/servercore:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/stable/nanoserver2022/docker/Dockerfile
+++ b/release/stable/nanoserver2022/docker/Dockerfile
@@ -6,8 +6,10 @@
 ARG InstallerVersion=nanoserver
 ARG dockerHost=mcr.microsoft.com
 ARG InstallerRepo=mcr.microsoft.com/powershell
-ARG NanoServerRepo=windows/nanoserver
+ARG NanoServerRepo=windows/server
 ARG tag=ltsc2022
+
+#mcr.microsoft.com/windows/server:ltsc2022
 
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away

--- a/release/stable/nanoserver2022/docker/Dockerfile
+++ b/release/stable/nanoserver2022/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 # Args used by from statements must be defined here:
 ARG InstallerVersion=nanoserver
-ARG dockerHost=mcr.microsoft.com/windows/server
+ARG dockerHost=mcr.microsoft.com
 ARG InstallerRepo=mcr.microsoft.com/powershell
 ARG NanoServerRepo=windows/nanoserver
 ARG tag=ltsc2022
@@ -44,7 +44,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive /installer/powershell.zip -DestinationPath \PowerShell
 
 # Install PowerShell into NanoServer
-FROM ${dockerHost}:${tag}
+FROM mcr.microsoft.com/windows/server:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/stable/nanoserver2022/meta.json
+++ b/release/stable/nanoserver2022/meta.json
@@ -19,6 +19,5 @@
     "TestProperties": {
         "size": 1
     },
-    "UseAcr": true,
-    "IsPrivate": true
+    "UseAcr": true
 }

--- a/release/stable/windowsservercore2022/docker/Dockerfile
+++ b/release/stable/windowsservercore2022/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG tag=ltsc2022
 
 # Use server core as an installer container to extract PowerShell,
 # As this is a multi-stage build, this stage will eventually be thrown away
-FROM ${dockerHost}/${WindowsServerCoreRepo}:${tag} AS installer-env
+FROM mcr.microsoft.com/${WindowsServerCoreRepo}:${tag} AS installer-env
 
 ARG PS_VERSION=6.2.0
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/PowerShell-${PS_VERSION}-win-x64.zip
@@ -35,7 +35,7 @@ RUN Write-host "Verifying valid Version..."; `
     Expand-Archive powershell.zip -DestinationPath  \PowerShell
 
 # Install PowerShell into WindowsServerCore
-FROM ${dockerHost}/${WindowsServerCoreRepo}:${tag}
+FROM mcr.microsoft.com/${WindowsServerCoreRepo}:${tag}
 
 # Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" `

--- a/release/stable/windowsservercore2022/meta.json
+++ b/release/stable/windowsservercore2022/meta.json
@@ -19,6 +19,5 @@
     "TestProperties": {
         "size": 1
     },
-    "UseAcr": true,
-    "IsPrivate": true
+    "UseAcr": true
 }


### PR DESCRIPTION
## PR Summary

Change FROM path to pull base image from different location when Windows LTSC 2022 releases publicly and let `isPrivate` in meta.json be false.

Pull from these locations for windowsservercore and nanoserver, respectively: 
`mcr.microsoft.com/windows/servercore:ltsc2022`
`mcr.microsoft.com/windows/server:ltsc2022`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
