### PR TITLE
Add alpine 3.13.6 images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "docker"
+    directory: "/release/preview/alpine313/docker"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
     directory: "/release/preview/centos8/dependabot"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,6 @@ version: 2
 
 # update_schedule: live is not supported by docker
 
-updates:
-  - package-ecosystem: "docker"
-    directory: "/release/preview/alpine312/docker"
-    schedule:
-      interval: "weekly"
-
   - package-ecosystem: "docker"
     directory: "/release/preview/alpine313/docker"
     schedule:

--- a/release/preview/alpine313/docker/Dockerfile
+++ b/release/preview/alpine313/docker/Dockerfile
@@ -1,0 +1,89 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Docker image file that describes an Alpine3.13 image with PowerShell installed from .tar.gz file(s)
+
+FROM alpine:3.13.6 AS installer-env
+
+# Define Args for the needed to add the package
+ARG PS_VERSION=7.0.0-preview.1
+ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-alpine-x64.tar.gz
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+ARG PS_INSTALL_VERSION=7-preview
+
+# Download the Linux tar.gz and save it
+ADD ${PS_PACKAGE_URL} /tmp/linux.tar.gz
+
+# define the folder we will be installing PowerShell to
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
+
+# Create the install folder
+RUN mkdir -p ${PS_INSTALL_FOLDER}
+
+# Unzip the Linux tar.gz
+RUN tar zxf /tmp/linux.tar.gz -C ${PS_INSTALL_FOLDER} -v
+
+# Start a new stage so we lose all the tar.gz layers from the final image
+FROM alpine:3.13.6
+
+# Copy only the files we need from the previous stage
+COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
+
+# Define Args and Env needed to create links
+ARG PS_INSTALL_VERSION=7-preview
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
+    \
+    # Define ENVs for Localization/Globalization
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    # set a fixed location for the Module analysis cache
+    PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-Alpine-3.13
+
+# Install dotnet dependencies and ca-certificates
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    \
+    # PSReadline/console dependencies
+    ncurses-terminfo-base \
+    \
+    # .NET Core dependencies
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+    lttng-ust \
+    \
+    # PowerShell remoting over SSH dependencies
+    openssh-client \
+    \
+    # Create the pwsh symbolic link that points to powershell
+    && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \
+    \
+    # Create the pwsh-preview symbolic link that points to powershell
+    && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh-preview \
+    # Give all user execute permissions and remove write permissions for others
+    && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
+    # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
+    && pwsh \
+        -NoLogo \
+        -NoProfile \
+        -Command " \
+          \$ErrorActionPreference = 'Stop' ; \
+          \$ProgressPreference = 'SilentlyContinue' ; \
+          while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \
+            Write-Host "'Waiting for $env:PSModuleAnalysisCachePath'" ; \
+            Start-Sleep -Seconds 6 ; \
+          }"
+
+CMD [ "pwsh" ]

--- a/release/preview/alpine313/meta.json
+++ b/release/preview/alpine313/meta.json
@@ -1,0 +1,18 @@
+{
+    "IsLinux" : true,
+    "UseLinuxVersion": false,
+    "PackageFormat": "powershell-${PS_VERSION}-linux-alpine-x64.tar.gz",
+    "osVersion": "Alpine 3.13",
+    "tagTemplates": [
+        "#psversion#-alpine-#shorttag#-#fulltag#",
+        "preview-alpine-#shorttag#"
+    ],
+    "shortTags": [
+        {"Tag": "3.13"}
+    ],
+    "SkipGssNtlmSspTests": true,
+    "SubImage": "test-deps",
+    "TestProperties": {
+        "size": 221
+    }
+}

--- a/release/preview/alpine313/test-deps/docker/Dockerfile
+++ b/release/preview/alpine313/test-deps/docker/Dockerfile
@@ -1,0 +1,38 @@
+# Docker image file that describes an Alpine image with PowerShell and test dependencies
+
+ARG BaseImage=mcr.microsoft.com/powershell:alpine-3.13.6
+
+FROM node:14.3.0-alpine as node
+
+# Do nothing, just added to borrow the already built node files.
+
+FROM ${BaseImage}
+
+ENV NODE_VERSION=14.3.0 \
+    YARN_VERSION=1.22.4 \
+    NVM_DIR="/root/.nvm" \
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-Alpine-3.13
+
+# workaround for Alpine to run in Azure DevOps
+ENV NODE_NO_WARNINGS=1
+
+# Copy node and yarn into image
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /opt/yarn-v${YARN_VERSION} /opt/yarn-v${YARN_VERSION}
+
+RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam \
+    && apk add \
+        bash \
+        sudo \
+        shadow \
+        openssl \
+        curl \
+    && apk del .pipeline-deps \
+    && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+    && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg
+
+LABEL com.azure.dev.pipelines.agent.handler.node.path="/usr/local/bin/node"
+
+# Use PowerShell as the default shell
+# Use array to avoid Docker prepending /bin/sh -c
+CMD [ "pwsh" ]

--- a/release/preview/alpine313/test-deps/meta.json
+++ b/release/preview/alpine313/test-deps/meta.json
@@ -1,0 +1,19 @@
+{
+    "IsLinux" : true,
+    "UseLinuxVersion": false,
+    "SkipGssNtlmSspTests": true,
+    "osVersion": "Alpine 3.13",
+    "tagTemplates": [
+        "#tag#"
+    ],
+    "OptionalTests": [
+        "test-deps",
+        "test-deps-musl"
+    ],
+    "TestProperties": {
+        "size": 295
+    },
+    "TagMapping": {
+        "^.*-alpine-3.13$" : "preview-alpine-3.13"
+    }
+}

--- a/release/stable/alpine313/docker/Dockerfile
+++ b/release/stable/alpine313/docker/Dockerfile
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Docker image file that describes an Alpine3.13 image with PowerShell installed from .tar.gz file(s)
+
+FROM alpine:3.13.6 AS installer-env
+
+# Define Args for the needed to add the package
+ARG PS_VERSION=7.0.0
+ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-alpine-x64.tar.gz
+ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+ARG PS_INSTALL_VERSION=7
+
+# Download the Linux tar.gz and save it
+ADD ${PS_PACKAGE_URL} /tmp/linux.tar.gz
+
+# define the folder we will be installing PowerShell to
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
+
+# Create the install folder
+RUN mkdir -p ${PS_INSTALL_FOLDER}
+
+# Unzip the Linux tar.gz
+RUN tar zxf /tmp/linux.tar.gz -C ${PS_INSTALL_FOLDER} -v
+
+# Start a new stage so we lose all the tar.gz layers from the final image
+FROM alpine:3.13.6
+
+# Copy only the files we need from the previous stage
+COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
+
+# Define Args and Env needed to create links
+ARG PS_INSTALL_VERSION=7
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
+    \
+    # Define ENVs for Localization/Globalization
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    # set a fixed location for the Module analysis cache
+    PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-Alpine-3.13
+
+# Install dotnet dependencies and ca-certificates
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    \
+    # PSReadline/console dependencies
+    ncurses-terminfo-base \
+    \
+    # .NET Core dependencies
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+    lttng-ust \
+    \
+    # PowerShell remoting over SSH dependencies
+    openssh-client \
+    \
+    # Create the pwsh symbolic link that points to powershell
+    && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \
+    \
+    # Give all user execute permissions and remove write permissions for others
+    && chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
+    # intialize powershell module cache
+    # and disable telemetry
+    && export POWERSHELL_TELEMETRY_OPTOUT=1 \
+    && pwsh \
+        -NoLogo \
+        -NoProfile \
+        -Command " \
+          \$ErrorActionPreference = 'Stop' ; \
+          \$ProgressPreference = 'SilentlyContinue' ; \
+          while(!(Test-Path -Path \$env:PSModuleAnalysisCachePath)) {  \
+            Write-Host "'Waiting for $env:PSModuleAnalysisCachePath'" ; \
+            Start-Sleep -Seconds 6 ; \
+          }"
+
+CMD [ "pwsh" ]

--- a/release/stable/alpine313/meta.json
+++ b/release/stable/alpine313/meta.json
@@ -1,0 +1,18 @@
+{
+    "IsLinux" : true,
+    "UseLinuxVersion": false,
+    "PackageFormat": "powershell-${PS_VERSION}-linux-alpine-x64.tar.gz",
+    "osVersion": "Alpine 3.13",
+    "tagTemplates": [
+        "#psversion#-alpine-#shorttag#-#fulltag#",
+        "alpine-#shorttag#"
+    ],
+    "shortTags": [
+        {"Tag": "3.13"}
+    ],
+    "SkipGssNtlmSspTests": true,
+    "SubImage": "test-deps",
+    "TestProperties": {
+        "size": 221
+    }
+}

--- a/release/stable/alpine313/test-deps/docker/Dockerfile
+++ b/release/stable/alpine313/test-deps/docker/Dockerfile
@@ -1,0 +1,38 @@
+# Docker image file that describes an Alpine image with PowerShell and test dependencies
+
+ARG BaseImage=mcr.microsoft.com/powershell:alpine-3.13.6
+
+FROM node:14.3.0-alpine as node
+
+# Do nothing, just added to borrow the already built node files.
+
+FROM ${BaseImage}
+
+ENV NODE_VERSION=14.3.0 \
+    YARN_VERSION=1.22.4 \
+    NVM_DIR="/root/.nvm" \
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-Alpine-3.13
+
+# workaround for Alpine to run in Azure DevOps
+ENV NODE_NO_WARNINGS=1
+
+# Copy node and yarn into image
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /opt/yarn-v${YARN_VERSION} /opt/yarn-v${YARN_VERSION}
+
+RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam \
+    && apk add \
+        bash \
+        sudo \
+        shadow \
+        openssl \
+        curl \
+    && apk del .pipeline-deps \
+    && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+    && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg
+
+LABEL com.azure.dev.pipelines.agent.handler.node.path="/usr/local/bin/node"
+
+# Use PowerShell as the default shell
+# Use array to avoid Docker prepending /bin/sh -c
+CMD [ "pwsh" ]

--- a/release/stable/alpine313/test-deps/meta.json
+++ b/release/stable/alpine313/test-deps/meta.json
@@ -1,0 +1,19 @@
+{
+    "IsLinux" : true,
+    "UseLinuxVersion": false,
+    "SkipGssNtlmSspTests": true,
+    "osVersion": "Alpine 3.13",
+    "tagTemplates": [
+        "#tag#"
+    ],
+    "OptionalTests": [
+        "test-deps",
+        "test-deps-musl"
+    ],
+    "TestProperties": {
+        "size": 295
+    },
+    "TagMapping": {
+        "^.*-alpine-3.13$" : "preview-alpine-3.13"
+    }
+}


### PR DESCRIPTION
## PR Summary

This PR adds preview and stable docker images based on alpine 3.13.6. The new tag is `3.13`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [x] alpine:3.13
- **OR**
  - [ ] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
  - [ ] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
