### PR TITLE
Remove broken flag from 20H2 images as now supported by ACR

### DIFF
--- a/release/lts/nanoserver20H2/meta.json
+++ b/release/lts/nanoserver20H2/meta.json
@@ -16,5 +16,5 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": true
+    "IsBroken": false
 }

--- a/release/lts/windowsservercore20H2/meta.json
+++ b/release/lts/windowsservercore20H2/meta.json
@@ -16,5 +16,4 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": false
 }

--- a/release/lts/windowsservercore20H2/meta.json
+++ b/release/lts/windowsservercore20H2/meta.json
@@ -16,5 +16,5 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": true
+    "IsBroken": false
 }

--- a/release/preview/nanoserver20H2/meta.json
+++ b/release/preview/nanoserver20H2/meta.json
@@ -17,5 +17,5 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": true
+    "IsBroken": false
 }

--- a/release/preview/nanoserver20H2/meta.json
+++ b/release/preview/nanoserver20H2/meta.json
@@ -17,5 +17,4 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": false
 }

--- a/release/preview/windowsservercore20H2/meta.json
+++ b/release/preview/windowsservercore20H2/meta.json
@@ -17,5 +17,5 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": true
+    "IsBroken": false
 }

--- a/release/preview/windowsservercore20H2/meta.json
+++ b/release/preview/windowsservercore20H2/meta.json
@@ -17,5 +17,4 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": false
 }

--- a/release/stable/nanoserver20H2/meta.json
+++ b/release/stable/nanoserver20H2/meta.json
@@ -17,5 +17,5 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": true
+    "IsBroken": false
 }

--- a/release/stable/nanoserver20H2/meta.json
+++ b/release/stable/nanoserver20H2/meta.json
@@ -17,5 +17,4 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": false
 }

--- a/release/stable/windowsservercore20H2/meta.json
+++ b/release/stable/windowsservercore20H2/meta.json
@@ -17,5 +17,5 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": true
+    "IsBroken": false
 }

--- a/release/stable/windowsservercore20H2/meta.json
+++ b/release/stable/windowsservercore20H2/meta.json
@@ -17,5 +17,4 @@
         "size": 1
     },
     "UseAcr": true,
-    "IsBroken": false
 }


### PR DESCRIPTION
## PR Summary

Remove broken flag from 20H2 images as now supported by ACR. Fixes #552.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **Adds a new image or tag**
  - [ ] Not Applicable
- **OR**
  - [x] Update [README.powershellcommunity.md](https://github.com/PowerShell/PowerShell-Docker/blob/master/docs/README.powershellcommunity.md)
  - [x] Update [vsts-ci.yml](https://github.com/PowerShell/PowerShell-Docker/blob/master/vsts-ci.yml)
