### PR TITLE
Fix duplicate check failure getting tag list

### DIFF
--- a/release/preview/alpine312/meta.json
+++ b/release/preview/alpine312/meta.json
@@ -13,6 +13,6 @@
     "SkipGssNtlmSspTests": true,
     "SubImage": "test-deps",
     "TestProperties": {
-        "size": 221
+        "size": 230
     }
 }

--- a/release/preview/alpine312/test-deps/meta.json
+++ b/release/preview/alpine312/test-deps/meta.json
@@ -11,6 +11,6 @@
         "test-deps-musl"
     ],
     "TestProperties": {
-        "size": 295
+        "size": 315
     }
 }

--- a/release/preview/centos7/meta.json
+++ b/release/preview/centos7/meta.json
@@ -12,6 +12,6 @@
     ],
     "SubImage": "test-deps",
     "TestProperties": {
-        "size": 550
+        "size": 586
     }
 }

--- a/release/preview/centos7/test-deps/meta.json
+++ b/release/preview/centos7/test-deps/meta.json
@@ -10,6 +10,6 @@
         "test-deps"
     ],
     "TestProperties": {
-        "size": 575
+        "size": 611
     }
 }

--- a/tools/buildHelper/buildHelper.psm1
+++ b/tools/buildHelper/buildHelper.psm1
@@ -470,9 +470,9 @@ function Get-DockerImageMetaDataWrapper
     {
         if((Test-Path $scriptPath) )
         {
+            Write-Verbose "Getting tags using script: $scriptPath" -Verbose
             # Get the tag data for the image
             $tagDataFromScript = @(& $scriptPath -CI:$CI.IsPresent @getTagsExtraParams | Where-Object {$_.FromTag})
-            Write-Verbose "tdfs count:$($tagDataFromScript.count)-$($Strict.IsPresent)"
             if($tagDataFromScript.count -eq 0 -and $Strict.IsPresent)
             {
                 throw "Did not get tag data from script for $scriptPath!"

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -47,7 +47,13 @@ stages:
       - pwsh: Write-Host "##vso[build.updatebuildnumber]$env:BUILD_SOURCEBRANCHNAME-$env:BUILD_SOURCEVERSION-$((get-date).ToString("yyyyMMddhhss"))"
         displayName: Set Build Name for Non-PR
         condition: ne(variables['Build.Reason'], 'PullRequest')
-      - pwsh: ./build.ps1 -CheckForDuplicateTags -Channel stable, preview, servicing, lts
+      - pwsh: |
+          try {
+            ./build.ps1 -CheckForDuplicateTags -Channel stable, preview, servicing, lts
+          } catch {
+            Get-Error
+            throw
+          }
         displayName: Check for Duplicate Tags
         condition: succeededOrFailed()
 

--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -49,7 +49,7 @@ stages:
         condition: ne(variables['Build.Reason'], 'PullRequest')
       - pwsh: |
           try {
-            ./build.ps1 -CheckForDuplicateTags -Channel stable, preview, servicing, lts
+            ./build.ps1 -CheckForDuplicateTags -Channel stable, preview, lts
           } catch {
             Get-Error
             throw


### PR DESCRIPTION
## PR Summary

Fix duplicate check failure getting tag list by removing services from duplicate check
* Also fix image sizes
* Also add get-error when dup check fails to know where it failed
* 
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
