### PR TITLE
Ubi8.4 image should have Version_ID of 8.4

### DIFF
--- a/release/7-2/ubi84/docker/Dockerfile
+++ b/release/7-2/ubi84/docker/Dockerfile
@@ -15,7 +15,6 @@ ARG PS_VERSION=7.2.2
 ARG PS_INSTALL_VERSION=7
 
 RUN --mount=type=cache,target=/var/cache/yum,rw \
-    yum update -y \
     && yum install -y \
       less \
       ncurses \
@@ -27,7 +26,6 @@ RUN --mount=type=cache,target=/var/cache/yum,rw \
     && yum clean all
 RUN --mount=type=cache,target=/var/cache/yum,rw \
     --mount=from=installer-env,target=/mnt/rpm,source=/tmp \
-    yum update -y \
     && yum localinstall -y \
       /mnt/rpm/linux.rpm \
     && yum upgrade-minimal -y --security \

--- a/release/7-2/ubi84/docker/Dockerfile
+++ b/release/7-2/ubi84/docker/Dockerfile
@@ -22,7 +22,6 @@ RUN --mount=type=cache,target=/var/cache/yum,rw \
       glibc-locale-source \
       glibc-langpack-en \
       libicu \
-    && yum upgrade-minimal -y --security \
     && yum clean all
 RUN --mount=type=cache,target=/var/cache/yum,rw \
     --mount=from=installer-env,target=/mnt/rpm,source=/tmp \

--- a/release/7-2/ubi84/docker/Dockerfile
+++ b/release/7-2/ubi84/docker/Dockerfile
@@ -15,7 +15,7 @@ ARG PS_VERSION=7.2.2
 ARG PS_INSTALL_VERSION=7
 
 RUN --mount=type=cache,target=/var/cache/yum,rw \
-    && yum install -y \
+    yum install -y \
       less \
       ncurses \
       openssh-clients \
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/var/cache/yum,rw \
     && yum clean all
 RUN --mount=type=cache,target=/var/cache/yum,rw \
     --mount=from=installer-env,target=/mnt/rpm,source=/tmp \
-    && yum localinstall -y \
+    yum localinstall -y \
       /mnt/rpm/linux.rpm \
     && yum upgrade-minimal -y --security \
     && yum clean all

--- a/release/7-3/ubi84/docker/Dockerfile
+++ b/release/7-3/ubi84/docker/Dockerfile
@@ -23,7 +23,6 @@ RUN --mount=type=cache,target=/var/cache/yum,rw \
       glibc-locale-source \
       glibc-langpack-en \
       libicu \
-    && yum upgrade-minimal -y --security \
     && yum clean all
 RUN --mount=type=cache,target=/var/cache/yum,rw \
     --mount=from=installer-env,target=/mnt/rpm,source=/tmp \

--- a/release/7-3/ubi84/docker/Dockerfile
+++ b/release/7-3/ubi84/docker/Dockerfile
@@ -16,7 +16,6 @@ ARG PS_VERSION=7.3.0-preview.1
 ARG PS_INSTALL_VERSION=7-preview
 
 RUN --mount=type=cache,target=/var/cache/yum,rw \
-    yum update -y \
     && yum install -y \
       less \
       ncurses \
@@ -28,7 +27,6 @@ RUN --mount=type=cache,target=/var/cache/yum,rw \
     && yum clean all
 RUN --mount=type=cache,target=/var/cache/yum,rw \
     --mount=from=installer-env,target=/mnt/rpm,source=/tmp \
-    yum update -y \
     && yum localinstall -y \
       /mnt/rpm/linux.rpm \
     && yum upgrade-minimal -y --security \

--- a/release/7-3/ubi84/docker/Dockerfile
+++ b/release/7-3/ubi84/docker/Dockerfile
@@ -16,7 +16,7 @@ ARG PS_VERSION=7.3.0-preview.1
 ARG PS_INSTALL_VERSION=7-preview
 
 RUN --mount=type=cache,target=/var/cache/yum,rw \
-    && yum install -y \
+    yum install -y \
       less \
       ncurses \
       openssh-clients \
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/var/cache/yum,rw \
     && yum clean all
 RUN --mount=type=cache,target=/var/cache/yum,rw \
     --mount=from=installer-env,target=/mnt/rpm,source=/tmp \
-    && yum localinstall -y \
+    yum localinstall -y \
       /mnt/rpm/linux.rpm \
     && yum upgrade-minimal -y --security \
     && yum clean all


### PR DESCRIPTION
## PR Summary

We need Ubi8.4 image to have VERSION_ID of 8.4, not 8.5. `Yum update -y` line of code which updates it to 8.5

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
