### PR TITLE
remove manifest list from ubuntu20.04

### DIFF
--- a/release/7-2/ubuntu20.04/meta.json
+++ b/release/7-2/ubuntu20.04/meta.json
@@ -12,9 +12,6 @@
         {"Tag": "focal"},
         {"Tag": "20.04"}
     ],
-    "manifestLists": [
-        "latest"
-    ],
     "TestProperties": {
         "size": 355
     },

--- a/release/7-3/ubuntu20.04/meta.json
+++ b/release/7-3/ubuntu20.04/meta.json
@@ -9,9 +9,6 @@
         {"Tag": "focal"},
         {"Tag": "20.04"}
     ],
-    "manifestLists": [
-        "preview"
-    ],
     "TestProperties": {
         "size": 355
     },


### PR DESCRIPTION
## PR Summary

Ubuntu22.04 will have `latest` and `preview` manifest list tags, so remove those from Ubuntu20.04

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
