### PR TITLE
ubi9 test deps Dockerfile should be using Ubi9 base image

### DIFF
--- a/release/7-3/ubi9/test-deps/docker/Dockerfile
+++ b/release/7-3/ubi9/test-deps/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image file that describes an CentOS7 image with PowerShell installed from Microsoft YUM Repo
-ARG BaseImage=mcr.microsoft.com/powershell:ubi-8.4
+ARG BaseImage=mcr.microsoft.com/powershell:ubi-9
 
 FROM ${BaseImage}
 


### PR DESCRIPTION
## PR Summary

Due to typo, Ubi9 test deps image accidentally uses Ubi8.4 base image for test, change to using Ubi9 for base image.

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
