### PR TITLE
add ubi to latest and preview manifest lists

### DIFF
--- a/release/7-2/ubi84/meta.json
+++ b/release/7-2/ubi84/meta.json
@@ -11,6 +11,9 @@
     "shortTags": [
         {"Tag": "8.4"}
     ],
+    "manifestLists": [
+        "latest"
+    ],
     "SubImage": "test-deps",
     "TestProperties": {
         "size": 725

--- a/release/7-3/ubi9/meta.json
+++ b/release/7-3/ubi9/meta.json
@@ -8,6 +8,9 @@
     "shortTags": [
         {"Tag": "9"}
     ],
+    "manifestLists": [
+        "preview"
+    ],
     "SubImage": "test-deps",
     "TestProperties": {
         "size": 502


### PR DESCRIPTION

## PR Summary

Add ubi84 to latest manifest list
Add ubi9 to preview manifest list

Then in [this MCR docs PR](https://github.com/microsoft/mcrdocs/pull/2766) update docs to get latest ubi and latest ubuntu image

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
