### PR TITLE
add arm32 ubuntu20 images and fix tag syntax for arm32 ubuntu18

### DIFF
--- a/release/7-2/ubuntu18.04-arm32v7/docker/Dockerfile
+++ b/release/7-2/ubuntu18.04-arm32v7/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. 
 # Licensed under the MIT License.
 
-FROM arm32v7/ubuntu:bionic AS installer-env
+FROM --platform=linux/arm/v7 ubuntu:bionic AS installer-env
 
 ARG PS_VERSION=6.2.3
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
@@ -36,7 +36,7 @@ RUN ls -l /tmp/powershell.tar.gz
     # Unzip the Linux tar.gz
 RUN tar zxf /tmp/powershell.tar.gz -C ${PS_INSTALL_FOLDER}
 
-FROM arm32v7/ubuntu:bionic AS final-image
+FROM --platform=linux/arm/v7 ubuntu:bionic AS final-image
 
 # Define Args and Env needed to create links
 ARG PS_INSTALL_VERSION=7

--- a/release/7-2/ubuntu18.04-arm32v7/docker/Dockerfile
+++ b/release/7-2/ubuntu18.04-arm32v7/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM --platform=linux/arm/v7 ubuntu:bionic AS installer-env
 
-ARG PS_VERSION=6.2.3
+ARG PS_VERSION=7.2.3
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
 ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7
@@ -40,7 +40,7 @@ FROM --platform=linux/arm/v7 ubuntu:bionic AS final-image
 
 # Define Args and Env needed to create links
 ARG PS_INSTALL_VERSION=7
-ARG PS_VERSION=6.2.3
+ARG PS_VERSION=7.2.3
 
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     \

--- a/release/7-2/ubuntu18.04-arm32v7/meta.json
+++ b/release/7-2/ubuntu18.04-arm32v7/meta.json
@@ -1,0 +1,23 @@
+{
+    "IsLinux" : true,
+    "UseLinuxVersion": false,
+    "PackageFormat": "powershell-${PS_VERSION}-linux-arm32.tar.gz",
+    "osVersion": "Ubuntu 18.04 ARM 32v7",
+    "SkipGssNtlmSspTests": true,
+    "Base64EncodePackageUrl": true,
+    "UseAcr": true,
+    "tagTemplates": [
+        "#psversion#-ubuntu-#shorttag#-arm32",
+        "ubuntu-#shorttag#-arm32"
+    ],
+    "shortTags": [
+        {"Tag": "bionic"},
+        {"Tag": "18.04"}
+    ],
+    "TestProperties": {
+        "size": 550,
+        "Arm32": true
+    },
+    "EndOfLife": "2023-04-02",
+    "DistributionState": "Validated"
+}

--- a/release/7-2/ubuntu20.04-arm32v7/docker/Dockerfile
+++ b/release/7-2/ubuntu20.04-arm32v7/docker/Dockerfile
@@ -1,0 +1,70 @@
+# Copyright (c) Microsoft Corporation. 
+# Licensed under the MIT License.
+
+FROM --platform=linux/arm/v7 ubuntu:focal AS installer-env
+
+ARG PS_VERSION=6.2.3
+ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
+ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+ARG PS_INSTALL_VERSION=7
+
+# define the folder we will be installing PowerShell to
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
+
+# Create the install folder
+RUN mkdir -p ${PS_INSTALL_FOLDER}
+
+ARG PS_PACKAGE_URL_BASE64
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends ca-certificates wget --yes
+
+RUN echo 'in task' \
+    && if [ -n "${PS_PACKAGE_URL_BASE64}" ]; then \
+        echo 'using base64' \
+        && export url=$(echo "${PS_PACKAGE_URL_BASE64}" | base64 --decode -);\
+    else \
+        echo 'using unencoded' \
+        && export url="${PS_PACKAGE_URL}"; \
+    fi \
+    && echo "url: $url" \
+    && wget -O /tmp/powershell.tar.gz "$url" \
+    && echo 'task done'
+
+RUN ls -l /tmp/powershell.tar.gz
+
+    # Unzip the Linux tar.gz
+RUN tar zxf /tmp/powershell.tar.gz -C ${PS_INSTALL_FOLDER}
+
+FROM --platform=linux/arm/v7 ubuntu:focal AS final-image
+
+# Define Args and Env needed to create links
+ARG PS_INSTALL_VERSION=7
+ARG PS_VERSION=6.2.3
+
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
+    \
+    # Define ENVs for Localization/Globalization
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    # set a fixed location for the Module analysis cache
+    PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm32v7-Ubuntu-18.04
+
+# Copy only the files we need from the previous stage
+COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
+
+
+RUN \
+  apt-get update \
+  && apt-get install --no-install-recommends ca-certificates libunwind8 libssl1.0 libicu60 less --yes
+
+    # Give all user execute permissions and remove write permissions for others
+RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
+    # Create the pwsh symbolic link that points to powershell
+    && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh
+
+# Use PowerShell as the default shell
+# Use array to avoid Docker prepending /bin/sh -c
+CMD [ "pwsh" ]

--- a/release/7-2/ubuntu20.04-arm32v7/meta.json
+++ b/release/7-2/ubuntu20.04-arm32v7/meta.json
@@ -1,0 +1,23 @@
+{
+    "IsLinux" : true,
+    "UseLinuxVersion": false,
+    "PackageFormat": "powershell-${PS_VERSION}-linux-arm32.tar.gz",
+    "osVersion": "Ubuntu 18.04 ARM 32v7",
+    "SkipGssNtlmSspTests": true,
+    "Base64EncodePackageUrl": true,
+    "UseAcr": true,
+    "tagTemplates": [
+        "#psversion#-ubuntu-#shorttag#-arm32",
+        "ubuntu-#shorttag#-arm32"
+    ],
+    "shortTags": [
+        {"Tag": "bionic"},
+        {"Tag": "18.04"}
+    ],
+    "TestProperties": {
+        "size": 550,
+        "Arm32": true
+    },
+    "EndOfLife": "2023-04-02",
+    "DistributionState": "Validated"
+}

--- a/release/7-2/ubuntu20.04-arm32v7/meta.json
+++ b/release/7-2/ubuntu20.04-arm32v7/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "UseLinuxVersion": false,
     "PackageFormat": "powershell-${PS_VERSION}-linux-arm32.tar.gz",
-    "osVersion": "Ubuntu 18.04 ARM 32v7",
+    "osVersion": "Ubuntu 20.04 ARM 32v7",
     "SkipGssNtlmSspTests": true,
     "Base64EncodePackageUrl": true,
     "UseAcr": true,
@@ -11,8 +11,8 @@
         "ubuntu-#shorttag#-arm32"
     ],
     "shortTags": [
-        {"Tag": "bionic"},
-        {"Tag": "18.04"}
+        {"Tag": "focal"},
+        {"Tag": "20.04"}
     ],
     "TestProperties": {
         "size": 550,

--- a/release/7-2/ubuntu20.04/docker/Dockerfile
+++ b/release/7-2/ubuntu20.04/docker/Dockerfile
@@ -5,7 +5,7 @@
 FROM ubuntu:20.04 AS installer-env
 
 # Define Args for the needed to add the package
-ARG PS_VERSION=7.2.3
+ARG PS_VERSION=6.2.4
 ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-x64.tar.gz
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7
@@ -27,7 +27,7 @@ RUN tar zxf /tmp/linux.tar.gz -C ${PS_INSTALL_FOLDER}
 # Start a new stage so we lose all the tar.gz layers from the final image
 FROM ubuntu:20.04 AS powershell
 
-ARG PS_VERSION=7.2.3
+ARG PS_VERSION=7.1.0
 ARG PS_INSTALL_VERSION=7
 
 # Copy only the files we need from the previous stage

--- a/release/7-2/ubuntu20.04/docker/Dockerfile
+++ b/release/7-2/ubuntu20.04/docker/Dockerfile
@@ -5,7 +5,7 @@
 FROM ubuntu:20.04 AS installer-env
 
 # Define Args for the needed to add the package
-ARG PS_VERSION=6.2.4
+ARG PS_VERSION=7.2.3
 ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-x64.tar.gz
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7
@@ -27,7 +27,7 @@ RUN tar zxf /tmp/linux.tar.gz -C ${PS_INSTALL_FOLDER}
 # Start a new stage so we lose all the tar.gz layers from the final image
 FROM ubuntu:20.04 AS powershell
 
-ARG PS_VERSION=7.1.0
+ARG PS_VERSION=7.2.3
 ARG PS_INSTALL_VERSION=7
 
 # Copy only the files we need from the previous stage

--- a/release/7-2/ubuntu22.04-arm32v7/docker/Dockerfile
+++ b/release/7-2/ubuntu22.04-arm32v7/docker/Dockerfile
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation. 
 # Licensed under the MIT License.
 
-FROM --platform=linux/arm/v7 ubuntu:focal AS installer-env
+FROM --platform=linux/arm/v7 ubuntu:jammy AS installer-env
 
-ARG PS_VERSION=7.2.3
+ARG PS_VERSION=7.2.4
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
 ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7
@@ -40,7 +40,7 @@ FROM --platform=linux/arm/v7 ubuntu:focal AS final-image
 
 # Define Args and Env needed to create links
 ARG PS_INSTALL_VERSION=7
-ARG PS_VERSION=7.2.3
+ARG PS_VERSION=7.2.4
 
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     \
@@ -50,7 +50,7 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     LANG=en_US.UTF-8 \
     # set a fixed location for the Module analysis cache
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm32v7-Ubuntu-20.04
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm32v7-Ubuntu-22.04
 
 # Copy only the files we need from the previous stage
 COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
@@ -58,7 +58,7 @@ COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershe
 
 RUN \
   apt-get update \
-  && apt-get install --no-install-recommends ca-certificates libunwind8 libssl1.0 libicu60 less --yes
+  && apt-get install --no-install-recommends ca-certificates libunwind8 libssl3 libicu70 less --yes
 
     # Give all user execute permissions and remove write permissions for others
 RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \

--- a/release/7-2/ubuntu22.04-arm32v7/meta.json
+++ b/release/7-2/ubuntu22.04-arm32v7/meta.json
@@ -18,6 +18,9 @@
         "size": 550,
         "Arm32": true
     },
+    "manifestLists": [
+        "latest"
+    ],
     "EndOfLife": "2023-04-02",
     "DistributionState": "Validated"
 }

--- a/release/7-2/ubuntu22.04-arm32v7/meta.json
+++ b/release/7-2/ubuntu22.04-arm32v7/meta.json
@@ -1,0 +1,23 @@
+{
+    "IsLinux" : true,
+    "UseLinuxVersion": false,
+    "PackageFormat": "powershell-${PS_VERSION}-linux-arm32.tar.gz",
+    "osVersion": "Ubuntu 22.04 ARM 32v7",
+    "SkipGssNtlmSspTests": true,
+    "Base64EncodePackageUrl": true,
+    "UseAcr": true,
+    "tagTemplates": [
+        "#psversion#-ubuntu-#shorttag#-arm32",
+        "ubuntu-#shorttag#-arm32"
+    ],
+    "shortTags": [
+        {"Tag": "jammy"},
+        {"Tag": "22.04"}
+    ],
+    "TestProperties": {
+        "size": 550,
+        "Arm32": true
+    },
+    "EndOfLife": "2023-04-02",
+    "DistributionState": "Validated"
+}

--- a/release/7-3/ubuntu20.04-arm32v7/docker/Dockerfile
+++ b/release/7-3/ubuntu20.04-arm32v7/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM --platform=linux/arm/v7 ubuntu:focal AS installer-env
 
-ARG PS_VERSION=7.2.3
+ARG PS_VERSION=7.3.0-preview.3
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
 ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7-preview
@@ -33,7 +33,7 @@ FROM --platform=linux/arm/v7 ubuntu:focal AS final-image
 
 # Define Args and Env needed to create links
 ARG PS_INSTALL_VERSION=7-preview
-ARG PS_VERSION=7.2.3
+ARG PS_VERSION=7.3.0-preview.3
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     \
     # Define ENVs for Localization/Globalization

--- a/release/7-3/ubuntu20.04-arm32v7/docker/Dockerfile
+++ b/release/7-3/ubuntu20.04-arm32v7/docker/Dockerfile
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+FROM --platform=linux/arm/v7 ubuntu:focal AS installer-env
+
+ARG PS_VERSION=6.2.3
+ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
+ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
+ARG PS_INSTALL_VERSION=7-preview
+# define the folder we will be installing PowerShell to
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
+# Create the install folder
+RUN mkdir -p ${PS_INSTALL_FOLDER}
+ARG PS_PACKAGE_URL_BASE64
+RUN apt-get update \
+    && apt-get install --no-install-recommends ca-certificates wget --yes
+RUN echo 'in task' \
+    && if [ -n "${PS_PACKAGE_URL_BASE64}" ]; then \
+        echo 'using base64' \
+        && export url=$(echo "${PS_PACKAGE_URL_BASE64}" | base64 --decode -);\
+    else \
+        echo 'using unencoded' \
+        && export url="${PS_PACKAGE_URL}"; \
+    fi \
+    && echo "url: $url" \
+    && wget -O /tmp/powershell.tar.gz "$url" \
+    && echo 'task done'
+RUN ls -l /tmp/powershell.tar.gz
+    # Unzip the Linux tar.gz
+RUN tar zxf /tmp/powershell.tar.gz -C ${PS_INSTALL_FOLDER}
+
+FROM --platform=linux/arm/v7 ubuntu:focal AS final-image
+
+# Define Args and Env needed to create links
+ARG PS_INSTALL_VERSION=7-preview
+ARG PS_VERSION=6.2.3
+ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
+    \
+    # Define ENVs for Localization/Globalization
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    # set a fixed location for the Module analysis cache
+    PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm32v7-Ubuntu-18.04
+# Copy only the files we need from the previous stage
+COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
+RUN \
+  apt-get update \
+  && apt-get install --no-install-recommends ca-certificates libssl1.0 libicu60 less --yes
+    # Give all user execute permissions and remove write permissions for others
+RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
+    # Create the pwsh symbolic link that points to powershell
+    && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh \
+    # Create the pwsh-preview symbolic link that points to powershell
+    && ln -s ${PS_INSTALL_FOLDER}/pwsh /usr/bin/pwsh-preview
+# Use PowerShell as the default shell
+# Use array to avoid Docker prepending /bin/sh -c
+CMD [ "pwsh" ]

--- a/release/7-3/ubuntu20.04-arm32v7/meta.json
+++ b/release/7-3/ubuntu20.04-arm32v7/meta.json
@@ -7,8 +7,8 @@
     "Base64EncodePackageUrl": true,
     "UseAcr": true,
     "tagTemplates": [
-        "#psversion#-arm32v7-ubuntu-#shorttag#",
-        "arm32v7-ubuntu-#shorttag#"
+        "preview-#psversion#-ubuntu-#shorttag#-arm32",
+        "preview-ubuntu-#shorttag#-arm32"
     ],
     "shortTags": [
         {"Tag": "bionic"},

--- a/release/7-3/ubuntu20.04-arm32v7/meta.json
+++ b/release/7-3/ubuntu20.04-arm32v7/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "UseLinuxVersion": false,
     "PackageFormat": "powershell-${PS_VERSION}-linux-arm32.tar.gz",
-    "osVersion": "Ubuntu 18.04 ARM 32v7",
+    "osVersion": "Ubuntu 20.04 ARM 32v7",
     "SkipGssNtlmSspTests": true,
     "Base64EncodePackageUrl": true,
     "UseAcr": true,
@@ -11,8 +11,8 @@
         "preview-ubuntu-#shorttag#-arm32"
     ],
     "shortTags": [
-        {"Tag": "bionic"},
-        {"Tag": "18.04"}
+        {"Tag": "focal"},
+        {"Tag": "20.04"}
     ],
     "TestProperties": {
         "size": 550,

--- a/release/7-3/ubuntu22.04-arm32v7/docker/Dockerfile
+++ b/release/7-3/ubuntu22.04-arm32v7/docker/Dockerfile
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-FROM --platform=linux/arm/v7 ubuntu:focal AS installer-env
+FROM --platform=linux/arm/v7 ubuntu:jammy AS installer-env
 
-ARG PS_VERSION=7.2.3
+ARG PS_VERSION=7.2.4
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
 ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7-preview
@@ -29,11 +29,11 @@ RUN ls -l /tmp/powershell.tar.gz
     # Unzip the Linux tar.gz
 RUN tar zxf /tmp/powershell.tar.gz -C ${PS_INSTALL_FOLDER}
 
-FROM --platform=linux/arm/v7 ubuntu:focal AS final-image
+FROM --platform=linux/arm/v7 ubuntu:jammy AS final-image
 
 # Define Args and Env needed to create links
 ARG PS_INSTALL_VERSION=7-preview
-ARG PS_VERSION=7.2.3
+ARG PS_VERSION=7.2.4
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     \
     # Define ENVs for Localization/Globalization
@@ -42,12 +42,12 @@ ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     LANG=en_US.UTF-8 \
     # set a fixed location for the Module analysis cache
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm32v7-Ubuntu-20.04
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm32v7-Ubuntu-22.04
 # Copy only the files we need from the previous stage
 COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]
 RUN \
   apt-get update \
-  && apt-get install --no-install-recommends ca-certificates libssl1.0 libicu60 less --yes
+  && apt-get install --no-install-recommends ca-certificates libssl3 libicu70 less --yes
     # Give all user execute permissions and remove write permissions for others
 RUN chmod a+x,o-w ${PS_INSTALL_FOLDER}/pwsh \
     # Create the pwsh symbolic link that points to powershell

--- a/release/7-3/ubuntu22.04-arm32v7/docker/Dockerfile
+++ b/release/7-3/ubuntu22.04-arm32v7/docker/Dockerfile
@@ -3,10 +3,11 @@
 
 FROM --platform=linux/arm/v7 ubuntu:jammy AS installer-env
 
-ARG PS_VERSION=7.2.4
+ARG PS_VERSION=7.3.0-preview.4
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
 ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7-preview
+
 # define the folder we will be installing PowerShell to
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION
 # Create the install folder
@@ -33,7 +34,7 @@ FROM --platform=linux/arm/v7 ubuntu:jammy AS final-image
 
 # Define Args and Env needed to create links
 ARG PS_INSTALL_VERSION=7-preview
-ARG PS_VERSION=7.2.4
+ARG PS_VERSION=7.3.0-preview.4
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     \
     # Define ENVs for Localization/Globalization

--- a/release/7-3/ubuntu22.04-arm32v7/meta.json
+++ b/release/7-3/ubuntu22.04-arm32v7/meta.json
@@ -1,0 +1,23 @@
+{
+    "IsLinux" : true,
+    "UseLinuxVersion": false,
+    "PackageFormat": "powershell-${PS_VERSION}-linux-arm32.tar.gz",
+    "osVersion": "Ubuntu 22.04 ARM 32v7",
+    "SkipGssNtlmSspTests": true,
+    "Base64EncodePackageUrl": true,
+    "UseAcr": true,
+    "tagTemplates": [
+        "preview-#psversion#-ubuntu-#shorttag#-arm32",
+        "preview-ubuntu-#shorttag#-arm32"
+    ],
+    "shortTags": [
+        {"Tag": "jammy"},
+        {"Tag": "22.04"}
+    ],
+    "TestProperties": {
+        "size": 550,
+        "Arm32": true
+    },
+    "EndOfLife": "2023-04-02",
+    "DistributionState": "Validated"
+}

--- a/release/7-3/ubuntu22.04-arm32v7/meta.json
+++ b/release/7-3/ubuntu22.04-arm32v7/meta.json
@@ -18,6 +18,9 @@
         "size": 550,
         "Arm32": true
     },
+    "manifestLists": [
+        "preview"
+    ],
     "EndOfLife": "2023-04-02",
     "DistributionState": "Validated"
 }


### PR DESCRIPTION
## PR Summary
Images will be given a new tag syntax. For images like Arm32v7, which has a different processor architecture than default amd64, have image name include arm32 (i.e format: os-osversion-arm32).

Adds ubuntu20.04 arm32v7 and ubuntu18.04 arm32v7 images.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
