### PR TITLE
Remove TagTemplates for Ubuntu preview arm images

### DIFF
--- a/release/7-3/ubuntu20.04-arm32v7/meta.json
+++ b/release/7-3/ubuntu20.04-arm32v7/meta.json
@@ -6,13 +6,9 @@
     "SkipGssNtlmSspTests": true,
     "Base64EncodePackageUrl": true,
     "UseAcr": true,
-    "tagTemplates": [
-        "preview-#psversion#-ubuntu-#shorttag#-arm32",
-        "preview-ubuntu-#shorttag#-arm32"
-    ],
     "shortTags": [
-        {"Tag": "focal"},
-        {"Tag": "20.04"}
+        {"Tag": "focal-arm32"},
+        {"Tag": "20.04-arm32"}
     ],
     "TestProperties": {
         "size": 550,

--- a/release/7-3/ubuntu22.04-arm32v7/meta.json
+++ b/release/7-3/ubuntu22.04-arm32v7/meta.json
@@ -6,13 +6,9 @@
     "SkipGssNtlmSspTests": true,
     "Base64EncodePackageUrl": true,
     "UseAcr": true,
-    "tagTemplates": [
-        "preview-#psversion#-ubuntu-#shorttag#-arm32",
-        "preview-ubuntu-#shorttag#-arm32"
-    ],
     "shortTags": [
-        {"Tag": "jammy"},
-        {"Tag": "22.04"}
+        {"Tag": "jammy-arm32"},
+        {"Tag": "22.04-arm32"}
     ],
     "TestProperties": {
         "size": 550,


### PR DESCRIPTION
Remove `tagTemplates` from Ubuntu arm images' meta.json files and specify processor architecture in `shortTags` instead. Specifying preview in the tag template as well as in the matrix generation adds duplicated "preview" to image name.

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
