### PR TITLE
Fix patching for ubi9 images

### DIFF
--- a/release/7-3/ubi9/docker/Dockerfile
+++ b/release/7-3/ubi9/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/var/cache/yum,rw \
     --mount=from=installer-env,target=/mnt/rpm,source=/tmp \
     yum localinstall -y \
       /mnt/rpm/linux.rpm \
-    && yum upgrade -y --security \
+    && yum upgrade -y \
     && yum clean all
 # Define ENVs for Localization/Globalization
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/${PS_INSTALL_VERSION} \

--- a/release/7-3/ubi9/test-deps/docker/Dockerfile
+++ b/release/7-3/ubi9/test-deps/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN yum install -y \
         git \
         unzip \
     && yum clean all \
-    && yum upgrade -y --security \
+    && yum upgrade -y \
     && rm -rf /var/cache/yum
 
 ENV POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-ubi-9

--- a/release/7-4/ubi9/docker/Dockerfile
+++ b/release/7-4/ubi9/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/var/cache/yum,rw \
     --mount=from=installer-env,target=/mnt/rpm,source=/tmp \
     yum localinstall -y \
       /mnt/rpm/linux.rpm \
-    && yum upgrade -y --security \
+    && yum upgrade -y \
     && yum clean all
 # Define ENVs for Localization/Globalization
 ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/${PS_INSTALL_VERSION} \

--- a/release/7-4/ubi9/test-deps/docker/Dockerfile
+++ b/release/7-4/ubi9/test-deps/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN yum install -y \
         git \
         unzip \
     && yum clean all \
-    && yum upgrade -y --security \
+    && yum upgrade -y \
     && rm -rf /var/cache/yum
 
 ENV POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-TestDeps-ubi-9


### PR DESCRIPTION
## PR Summary

UBI doesn't publish security patches as security patches, so we need to remove the filter

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
