### PR TITLE
Update the package name for Alpine tar gz packages

### DIFF
--- a/release/7-4/alpine315/docker/Dockerfile
+++ b/release/7-4/alpine315/docker/Dockerfile
@@ -8,7 +8,7 @@ FROM ${hostRegistry}/alpine:3.15 AS installer-env
 
 # Define Args for the needed to add the package
 ARG PS_VERSION=7.3.0-preview.8
-ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-alpine-x64.tar.gz
+ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-musl-x64.tar.gz
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7-preview
 

--- a/release/7-4/alpine315/meta.json
+++ b/release/7-4/alpine315/meta.json
@@ -1,7 +1,7 @@
 {
     "IsLinux" : true,
     "UseLinuxVersion": false,
-    "PackageFormat": "powershell-${PS_VERSION}-linux-alpine-x64.tar.gz",
+    "PackageFormat": "powershell-${PS_VERSION}-linux-musl-x64.tar.gz",
     "osVersion": "Alpine 3.15",
     "shortDistroName": "alpine",
     "shortTags": [

--- a/release/7-4/alpine316/docker/Dockerfile
+++ b/release/7-4/alpine316/docker/Dockerfile
@@ -7,7 +7,7 @@ FROM ${hostRegistry}/alpine:3.16 AS installer-env
 
 # Define Args for the needed to add the package
 ARG PS_VERSION=7.3.0-preview.8
-ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-alpine-x64.tar.gz
+ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-musl-x64.tar.gz
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7-preview
 

--- a/release/7-4/alpine316/meta.json
+++ b/release/7-4/alpine316/meta.json
@@ -1,7 +1,7 @@
 {
     "IsLinux" : true,
     "UseLinuxVersion": false,
-    "PackageFormat": "powershell-${PS_VERSION}-linux-alpine-x64.tar.gz",
+    "PackageFormat": "powershell-${PS_VERSION}-linux-musl-x64.tar.gz",
     "osVersion": "Alpine 3.16",
     "shortDistroName": "alpine",
     "shortTags": [

--- a/release/7-4/alpine317/docker/Dockerfile
+++ b/release/7-4/alpine317/docker/Dockerfile
@@ -7,7 +7,7 @@ FROM ${hostRegistry}/alpine:3.17 AS installer-env
 
 # Define Args for the needed to add the package
 ARG PS_VERSION=7.3.0-preview.8
-ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-alpine-x64.tar.gz
+ARG PS_PACKAGE=powershell-${PS_VERSION}-linux-musl-x64.tar.gz
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 ARG PS_INSTALL_VERSION=7-preview
 

--- a/release/7-4/alpine317/meta.json
+++ b/release/7-4/alpine317/meta.json
@@ -1,7 +1,7 @@
 {
     "IsLinux" : true,
     "UseLinuxVersion": false,
-    "PackageFormat": "powershell-${PS_VERSION}-linux-alpine-x64.tar.gz",
+    "PackageFormat": "powershell-${PS_VERSION}-linux-musl-x64.tar.gz",
     "osVersion": "Alpine 3.17",
     "shortDistroName": "alpine",
     "shortTags": [


### PR DESCRIPTION
## PR Summary

Update the alpine tar gz package name to be linux-musl-x64.tar.gz

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
