### PR TITLE
Set correct arm64v8 info for mariner2

### DIFF
--- a/assets/matrix.json
+++ b/assets/matrix.json
@@ -388,7 +388,7 @@
       "ImageName": "mariner2-arm64",
       "IsLinux": true,
       "JobName": "mariner2_arm64",
-      "OsVersion": "Mariner 2.0 ARM 64v7 (In Validation)",
+      "OsVersion": "Mariner 2.0 ARM 64v8 (In Validation)",
       "TagList": "preview-7.4-mariner-2.0-arm64;preview-mariner-2.0-arm64",
       "UseInCI": false
     },
@@ -611,7 +611,7 @@
       "ImageName": "mariner2-arm64",
       "IsLinux": true,
       "JobName": "mariner2_arm64",
-      "OsVersion": "Mariner 2.0 ARM 64v7 (In Validation)",
+      "OsVersion": "Mariner 2.0 ARM 64v8 (In Validation)",
       "TagList": "7.3-mariner-2.0-arm64;mariner-2.0-arm64",
       "UseInCI": false
     },

--- a/release/7-3/mariner2-arm64/docker/Dockerfile
+++ b/release/7-3/mariner2-arm64/docker/Dockerfile
@@ -52,7 +52,7 @@ FROM --platform=linux/arm64 mcr.microsoft.com/cbl-mariner/base/core:2.0 AS final
         LANG=en_US.UTF-8 \
         # set a fixed location for the Module analysis cache
         PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v7-Mariner-2
+        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v8-Mariner-2
 
     # Copy only the files we need from the previous stage
     COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]

--- a/release/7-3/mariner2-arm64/meta.json
+++ b/release/7-3/mariner2-arm64/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "UseLinuxVersion": false,
     "PackageFormat": "powershell${channelTag}-${PS_VERSION}-linux-arm64.tar.gz",
-    "osVersion": "Mariner 2.0 ARM 64v7",
+    "osVersion": "Mariner 2.0 ARM 64v8",
     "SkipGssNtlmSspTests": true,
     "ShortDistroName": "mariner",
     "shortTags": [

--- a/release/7-4/azurelinux3-arm64/meta.json
+++ b/release/7-4/azurelinux3-arm64/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "UseLinuxVersion": false,
     "PackageFormat": "powershell-${PS_VERSION}-1.cm.aarch64.rpm",
-    "osVersion": "Azure Linux 3.0 ARM 64v7",
+    "osVersion": "Azure Linux 3.0 ARM 64v8",
     "SkipGssNtlmSspTests": true,
     "ShortDistroName": "azurelinux",
     "shortTags": [

--- a/release/7-4/mariner2-arm64/docker/Dockerfile
+++ b/release/7-4/mariner2-arm64/docker/Dockerfile
@@ -44,7 +44,7 @@ FROM setup-tdnf-repa AS powershell
         LANG=en_US.UTF-8 \
         # set a fixed location for the Module analysis cache
         PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-Mariner-2.0
+        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v8-Mariner-2.0
 
     RUN --mount=type=cache,target=/var/cache/tdnf \
         # install dependencies

--- a/release/7-4/mariner2-arm64/meta.json
+++ b/release/7-4/mariner2-arm64/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "UseLinuxVersion": false,
     "PackageFormat": "powershell-${PS_VERSION}-1.cm.aarch64.rpm",
-    "osVersion": "Mariner 2.0 ARM 64v7",
+    "osVersion": "Mariner 2.0 ARM 64v8",
     "SkipGssNtlmSspTests": true,
     "ShortDistroName": "mariner",
     "shortTags": [

--- a/release/7-5/azurelinux3-arm64/docker/Dockerfile
+++ b/release/7-5/azurelinux3-arm64/docker/Dockerfile
@@ -51,7 +51,7 @@ FROM setup-tdnf-repa AS powershell
         LANG=en_US.UTF-8 \
         # set a fixed location for the Module analysis cache
         PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v7-AzureLinux-3
+        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v8-AzureLinux-3
 
     RUN --mount=type=cache,target=/var/cache/tdnf \
         # install dependencies

--- a/release/7-5/azurelinux3-arm64/meta.json
+++ b/release/7-5/azurelinux3-arm64/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "UseLinuxVersion": false,
     "PackageFormat": "powershell${channelTag}-${PS_VERSION}-1.cm.aarch64.rpm",
-    "osVersion": "Azure Linux 3.0 ARM 64v7",
+    "osVersion": "Azure Linux 3.0 ARM 64v8",
     "SkipGssNtlmSspTests": true,
     "ShortDistroName": "azurelinux",
     "shortTags": [

--- a/release/7-5/mariner2-arm64/docker/Dockerfile
+++ b/release/7-5/mariner2-arm64/docker/Dockerfile
@@ -51,7 +51,7 @@ FROM setup-tdnf-repa AS powershell
         LANG=en_US.UTF-8 \
         # set a fixed location for the Module analysis cache
         PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v7-Mariner-2
+        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v8-Mariner-2
 
     RUN --mount=type=cache,target=/var/cache/tdnf \
         # install dependencies

--- a/release/7-5/mariner2-arm64/meta.json
+++ b/release/7-5/mariner2-arm64/meta.json
@@ -1,12 +1,14 @@
 {
-    "IsLinux" : true,
+    "IsLinux": true,
     "UseLinuxVersion": false,
     "PackageFormat": "powershell${channelTag}-${PS_VERSION}-1.cm.aarch64.rpm",
-    "osVersion": "Mariner 2.0 ARM 64v7",
+    "osVersion": "Mariner 2.0 ARM 64v8",
     "SkipGssNtlmSspTests": true,
     "ShortDistroName": "mariner",
     "shortTags": [
-        {"Tag": "2.0-arm64"}
+        {
+            "Tag": "2.0-arm64"
+        }
     ],
     "TestProperties": {
         "size": 404,

--- a/release/7-6/azurelinux3-arm64/docker/Dockerfile
+++ b/release/7-6/azurelinux3-arm64/docker/Dockerfile
@@ -51,7 +51,7 @@ FROM setup-tdnf-repa AS powershell
         LANG=en_US.UTF-8 \
         # set a fixed location for the Module analysis cache
         PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v7-AzureLinux-3
+        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v8-AzureLinux-3
 
     RUN --mount=type=cache,target=/var/cache/tdnf \
         # install dependencies

--- a/release/7-6/azurelinux3-arm64/meta.json
+++ b/release/7-6/azurelinux3-arm64/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "UseLinuxVersion": false,
     "PackageFormat": "powershell${channelTag}-${PS_VERSION}-1.cm.aarch64.rpm",
-    "osVersion": "Azure Linux 3.0 ARM 64v7",
+    "osVersion": "Azure Linux 3.0 ARM 64v8",
     "SkipGssNtlmSspTests": true,
     "ShortDistroName": "azurelinux",
     "shortTags": [

--- a/release/7-6/mariner2-arm64/docker/Dockerfile
+++ b/release/7-6/mariner2-arm64/docker/Dockerfile
@@ -51,7 +51,7 @@ FROM setup-tdnf-repa AS powershell
         LANG=en_US.UTF-8 \
         # set a fixed location for the Module analysis cache
         PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v7-Mariner-2
+        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-arm64v8-Mariner-2
 
     RUN --mount=type=cache,target=/var/cache/tdnf \
         # install dependencies

--- a/release/7-6/mariner2-arm64/meta.json
+++ b/release/7-6/mariner2-arm64/meta.json
@@ -2,7 +2,7 @@
     "IsLinux" : true,
     "UseLinuxVersion": false,
     "PackageFormat": "powershell${channelTag}-${PS_VERSION}-1.cm.aarch64.rpm",
-    "osVersion": "Mariner 2.0 ARM 64v7",
+    "osVersion": "Mariner 2.0 ARM 64v8",
     "SkipGssNtlmSspTests": true,
     "ShortDistroName": "mariner",
     "shortTags": [


### PR DESCRIPTION
## PR Summary

Arm64 should be `v8` instead of `v7`. From wiki: "It was first introduced with the [Armv8-A](https://en.wikipedia.org/wiki/ARM_architecture_family#64/32-bit_architecture) architecture"

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
