### PR TITLE
Fix broken MAR link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ with their size being the sum of the base image (200 megabytes)
 plus the uncompressed package (120 megabytes),
 and about 120 megabytes of .NET Core and bootstrapping dependencies.
 
-[docker-release]: https://mcr.microsoft.com/en-us/product/powershell/about
+[docker-release]: https://mcr.microsoft.com/product/powershell/about
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ with their size being the sum of the base image (200 megabytes)
 plus the uncompressed package (120 megabytes),
 and about 120 megabytes of .NET Core and bootstrapping dependencies.
 
-[docker-release]: [https://mcr.microsoft.com/powershell](https://mcr.microsoft.com/en-us/product/powershell/about)
+[docker-release]: https://mcr.microsoft.com/product/powershell/about
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ with their size being the sum of the base image (200 megabytes)
 plus the uncompressed package (120 megabytes),
 and about 120 megabytes of .NET Core and bootstrapping dependencies.
 
-[docker-release]: https://mcr.microsoft.com/product/powershell/about
+[docker-release]: https://mcr.microsoft.com/en-us/product/powershell/about
 
 ## Community
 


### PR DESCRIPTION
## PR Summary

The MAR link in the readme is broken - no link is shown at all even though it was clearly intended to be one.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `Dockerfile`, `.sh`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
  - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
